### PR TITLE
Update example files for multi-satellite format

### DIFF
--- a/examples/cli-workflow-akeneo-to-csv/satellite.yaml
+++ b/examples/cli-workflow-akeneo-to-csv/satellite.yaml
@@ -1,87 +1,89 @@
-satellite:
-  filesystem:
-    path: build/
-  composer:
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.3"
-      - "php-etl/workflow:^0.1"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.2"
-      - "akeneo/api-php-client-ee"
-      - "diglin/sylius-api-php-client"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-      - "monolog/monolog:^2.0"
-      - "elasticsearch/elasticsearch"
-  workflow:
-    jobs:
-    - name: 'Lorem ipsum dolor'
-      pipeline:
-        steps:
-        - akeneo:
-            extractor:
-              type: category
-              method: all
-            client:
-              api_url: 'http://localhost:8080'
-              client_id: '5_5dxapwm2rs4kkso8wgwk08o88gg0wc0owkgsgg0gkcwos4o0wo'
-              secret: 34n14k1ajy800g0ocww8w8cwckogoc844ggwcs8gkg8w4k4888
-              username: 'kiboko_2145'
-              password: 62d0f1090
-#          logger:
-#            channel: pipeline
-#            destinations:
-#              - elasticsearch:
-#                  level: warning
-#                  hosts:
-#                    - elasticsearch.example.com:9200
-        - csv:
-            loader:
-              file_path: categories.csv
-              delimiter: ','
-              enclosure: '"'
-              escape: '\'
-#          logger:
-#            channel: pipeline
-#            destinations:
-#              - elasticsearch:
-#                  level: warning
-#                  hosts:
-#                    - elasticsearch.example.com:9200
-    - name: 'Sit amet consecutir'
-      pipeline:
-        steps:
-        - akeneo:
-            extractor:
-              type: product
-              method: all
-            client:
-              api_url: 'http://localhost:8080'
-              client_id: '5_5dxapwm2rs4kkso8wgwk08o88gg0wc0owkgsgg0gkcwos4o0wo'
-              secret: 34n14k1ajy800g0ocww8w8cwckogoc844ggwcs8gkg8w4k4888
-              username: 'kiboko_2145'
-              password: 62d0f1090
-#          logger:
-#            channel: pipeline
-#            destinations:
-#              - elasticsearch:
-#                  level: warning
-#                  hosts:
-#                    - elasticsearch.example.com:9200
-        - csv:
-            loader:
-              file_path: products.csv
-              delimiter: ','
-              enclosure: '"'
-              escape: '\'
-#          logger:
-#            channel: pipeline
-#            destinations:
-#              - elasticsearch:
-#                  level: warning
-#                  hosts:
-#                    - elasticsearch.example.com:9200
+version: '2'
+satellites:
+  - name: 'Akeneo categories and products to separate CSVs'
+    filesystem:
+      path: build/
+    composer:
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.3"
+        - "php-etl/workflow:^0.1"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.2"
+        - "akeneo/api-php-client-ee"
+        - "diglin/sylius-api-php-client"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+        - "monolog/monolog:^2.0"
+        - "elasticsearch/elasticsearch"
+    workflow:
+      jobs:
+      - name: "Lorem ipsum dolor'
+        pipeline:
+          steps:
+          - akeneo:
+              extractor:
+                type: category
+                method: all
+              client:
+                api_url: 'http://localhost:8080'
+                client_id: '5_5dxapwm2rs4kkso8wgwk08o88gg0wc0owkgsgg0gkcwos4o0wo'
+                secret: 34n14k1ajy800g0ocww8w8cwckogoc844ggwcs8gkg8w4k4888
+                username: 'kiboko_2145'
+                password: 62d0f1090
+  #          logger:
+  #            channel: pipeline
+  #            destinations:
+  #              - elasticsearch:
+  #                  level: warning
+  #                  hosts:
+  #                    - elasticsearch.example.com:9200
+          - csv:
+              loader:
+                file_path: categories.csv
+                delimiter: ','
+                enclosure: '"'
+                escape: '\'
+  #          logger:
+  #            channel: pipeline
+  #            destinations:
+  #              - elasticsearch:
+  #                  level: warning
+  #                  hosts:
+  #                    - elasticsearch.example.com:9200
+      - name: 'Sit amet consecutir'
+        pipeline:
+          steps:
+          - akeneo:
+              extractor:
+                type: product
+                method: all
+              client:
+                api_url: 'http://localhost:8080'
+                client_id: '5_5dxapwm2rs4kkso8wgwk08o88gg0wc0owkgsgg0gkcwos4o0wo'
+                secret: 34n14k1ajy800g0ocww8w8cwckogoc844ggwcs8gkg8w4k4888
+                username: 'kiboko_2145'
+                password: 62d0f1090
+  #          logger:
+  #            channel: pipeline
+  #            destinations:
+  #              - elasticsearch:
+  #                  level: warning
+  #                  hosts:
+  #                    - elasticsearch.example.com:9200
+          - csv:
+              loader:
+                file_path: products.csv
+                delimiter: ','
+                enclosure: '"'
+                escape: '\'
+  #          logger:
+  #            channel: pipeline
+  #            destinations:
+  #              - elasticsearch:
+  #                  level: warning
+  #                  hosts:
+  #                    - elasticsearch.example.com:9200

--- a/examples/cli-workflow-csv-to-ldjson/satellite.yaml
+++ b/examples/cli-workflow-csv-to-ldjson/satellite.yaml
@@ -1,35 +1,37 @@
-satellite:
-  filesystem:
-    path: build/
-  composer:
-    require:
-      - php-etl/pipeline:^0.3.0
-      - php-etl/bucket:^0.2.0
-      - php-etl/csv-flow:^0.2.0
-      - psr/log:^1.1
-  workflow:
-    jobs:
-      - name: 'Products Pipeline'
-        pipeline:
-          steps:
-            - csv:
-                extractor:
-                  file_path: '../data/products.csv'
-            - fastmap:
-                map:
-                  - copy: '[sku]'
-                    field: '[identifier]'
-            - stream:
-                loader:
-                  destination: '../data/products.ldjson'
-                  format: 'json'
-      - name: 'Customers Pipeline'
-        pipeline:
-          steps:
-            - csv:
-                extractor:
-                  file_path: '../data/customers.csv'
-            - stream:
-                loader:
-                  destination: '../data/customers.ldjson'
-                  format: 'json'
+version: '2'
+satellites:
+  - name: "Products CSV to LDJSON"
+    filesystem:
+      path: build/
+    composer:
+      require:
+        - php-etl/pipeline:^0.3.0
+        - php-etl/bucket:^0.2.0
+        - php-etl/csv-flow:^0.2.0
+        - psr/log:^1.1
+    workflow:
+      jobs:
+        - name: 'Products Pipeline'
+          pipeline:
+            steps:
+              - csv:
+                  extractor:
+                    file_path: '../data/products.csv'
+              - fastmap:
+                  map:
+                    - copy: '[sku]'
+                      field: '[identifier]'
+              - stream:
+                  loader:
+                    destination: '../data/products.ldjson'
+                    format: 'json'
+        - name: 'Customers Pipeline'
+          pipeline:
+            steps:
+              - csv:
+                  extractor:
+                    file_path: '../data/customers.csv'
+              - stream:
+                  loader:
+                    destination: '../data/customers.ldjson'
+                    format: 'json'

--- a/examples/filesystem/cli-pipeline-akeneo-to-csv-multiple-files/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-csv-multiple-files/satellite.yaml
@@ -1,47 +1,49 @@
-satellite:
-  filesystem:
-    path: build
-  composer:
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\AkeneoToSylius\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.3.0"
-      - "php-etl/fast-map:^0.2.0"
-      - "php-etl/csv-flow:^0.2.0"
-      - "akeneo/api-php-client-ee"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    expression_language:
-      - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: category
-          method: all
-        client:
-          api_url: 'http://demo.akeneo.com/'
-          client_id: 5_1yq9g82il7usk44ks4cw0048ogos84wcgsskscg48g88sk8wgk
-          secret: 5mva179pbig4g8gck80cskwscko4wwkgokcg8gg4o0sc8sgk8w
-          username: kiboko_5112
-          password: b2ed66240
-    - fastmap:
-        map:
-          - field: '[code]'
-            copy: '[code]'
-          - field: '[name]'
-            expression: 'input["labels"]["fr_FR"]'
-          - field: '[staticValue]'
-            constant: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mollis efficitur justo, id facilisis elit venenatis et. Sed fermentum posuere convallis. Phasellus lectus neque, bibendum sit amet enim imperdiet, dignissim blandit nisi. Donec nec neque nisi. Vivamus luctus facilisis nibh id rhoncus. Vestibulum eget facilisis tortor. Etiam at cursus enim, vitae mollis ex. Proin at velit at erat bibendum ultricies. Duis ut velit malesuada, placerat nisl a, ultrices tortor.'
-    - csv:
-        expression_language:
-          - 'Kiboko\Component\StringExpressionLanguage\StringExpressionLanguageProvider'
-        loader:
-          file_path: '@=format("PRODUCT_%06d.csv", index)'
-          max_lines : 20
-          delimiter: ','
-          enclosure: '"'
-          escape: '\'
+version: '2'
+satellites:
+  - name: 'Akeneo to multiple CSVs'
+    filesystem:
+      path: build
+    composer:
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\AkeneoToSylius\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.3.0"
+        - "php-etl/fast-map:^0.2.0"
+        - "php-etl/csv-flow:^0.2.0"
+        - "akeneo/api-php-client-ee"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      expression_language:
+        - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: category
+            method: all
+          client:
+            api_url: 'http://demo.akeneo.com/'
+            client_id: 5_1yq9g82il7usk44ks4cw0048ogos84wcgsskscg48g88sk8wgk
+            secret: 5mva179pbig4g8gck80cskwscko4wwkgokcg8gg4o0sc8sgk8w
+            username: kiboko_5112
+            password: b2ed66240
+      - fastmap:
+          map:
+            - field: '[code]'
+              copy: '[code]'
+            - field: '[name]'
+              expression: 'input["labels"]["fr_FR"]'
+            - field: '[staticValue]'
+              constant: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mollis efficitur justo, id facilisis elit venenatis et. Sed fermentum posuere convallis. Phasellus lectus neque, bibendum sit amet enim imperdiet, dignissim blandit nisi. Donec nec neque nisi. Vivamus luctus facilisis nibh id rhoncus. Vestibulum eget facilisis tortor. Etiam at cursus enim, vitae mollis ex. Proin at velit at erat bibendum ultricies. Duis ut velit malesuada, placerat nisl a, ultrices tortor.'
+      - csv:
+          expression_language:
+            - 'Kiboko\Component\StringExpressionLanguage\StringExpressionLanguageProvider'
+          loader:
+            file_path: '@=format("PRODUCT_%06d.csv", index)'
+            max_lines : 20
+            delimiter: ','
+            enclosure: '"'
+            escape: '\'

--- a/examples/filesystem/cli-pipeline-akeneo-to-csv/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-csv/satellite.yaml
@@ -1,150 +1,152 @@
-satellite:
-  filesystem:
-    path: build/
-  composer:
-    require:
-      - "php-etl/pipeline:^0.3"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.2"
-      - "php-etl/rabbitmq-flow:^0.1"
-      - "akeneo/api-php-client-ee"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: productModel
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '>', value: 70, scope: ecommerce }
-            - { field: completeness, operator: '<', value: 85, scope: ecommerce }
-            - { field: categories, operator: IN, value: winter_collection }
-            - { field: family, operator: IN, value: [ camcorders, digital_cameras ] }
-        client:
-          api_url: '@=env("AKENEO_URL")'
-          client_id: '@=env("AKENEO_CLIENT_ID")'
-          secret: '@=env("AKENEO_CLIENT_SECRET")'
-          username: '@=env("AKENEO_USERNAME")'
-          password: '@=env("AKENEO_PASSWORD")'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-          - rabbitmq:
-              host: rabbitmq.example.com
-              port: 5432
-              vhost: /
-              exchange: default
-              topic: foo.rejects
-    - fastmap:
-        map:
-          - field: '[sku]'
-            copy: '[sku]'
-          - field: '[title]'
-            expression: 'input["sku"] ~" | "~ input["name"]'
-          - field: '[name]'
-            copy: '[name]'
-          - field: '[staticValue]'
-            constant: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mollis efficitur justo, id facilisis elit venenatis et. Sed fermentum posuere convallis. Phasellus lectus neque, bibendum sit amet enim imperdiet, dignissim blandit nisi. Donec nec neque nisi. Vivamus luctus facilisis nibh id rhoncus. Vestibulum eget facilisis tortor. Etiam at cursus enim, vitae mollis ex. Proin at velit at erat bibendum ultricies. Duis ut velit malesuada, placerat nisl a, ultrices tortor.'
-          - field: '[foo]'
-            expression: 'input'
-            map:
-              - field: '[bar]'
-                copy: '[bar]'
-          - field: '[foo]'
-            expression: 'input'
-            list:
-              - field: '[bar]'
-                copy: '[bar]'
-#          - field: '[descriptions]'
-#            class: 'Pipeline\Usage'
-#            expression: 'input["foo"]'
-#            object:
-#              - field: 'usage'
-#                expression: '"Usage: " ~ input["usage"]'
-#              - field: 'warning'
-#                copy: '[warning]'
-#              - field: 'notice'
-#                copy: '[notice]'
-#          - field: '[messages]'
-#            class: 'Foo\DTO\Messages'
-#            expression: 'input'
-#            collection:
-#            - field: 'usage'
-#              expression: '"Usage: " ~ input["usage"]'
-#            - field: 'warning'
-#              copy: '[warning]'
-#            - field: 'notice'
-#              copy: '[notice]'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-          - rabbitmq:
-              host: rabbitmq.example.com
-              port: 5432
-              vhost: /
-              exchange: default
-              topic: foo.rejects
-    - akeneo:
-        expression_language:
-          - 'Kiboko\Component\ArrayExpressionLanguage\ArrayExpressionLanguageProvider'
-        lookup:
-          conditional:
-            - condition: 'input["type"] === "pim_attribute_simpleselect"'
-              type: attributeOption
-              code: '@=input["code"]'
-              method: all
-              search:
-                - { field: "attributeOption_attribute", operator: "=", value: '@=input["code"]' }
-              merge:
-                map:
-                  - field: '[options]'
-                    expression: 'join(lookup, ",")'
-        client:
-          api_url: 'http://localhost:8080'
-          client_id: '1_3clz4rzonukgsgoscoc488w0c4k0so48o0owc0k0sc40wso08g'
-          secret: '9tw5v88wl1s8s4ws8wsgk08gwkoo484cwc4k00wwkwosgwow4'
-          username: 'proximis_3328'
-          password: '93b66a306'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-          - rabbitmq:
-              host: rabbitmq.example.com
-              port: 5432
-              vhost: /
-              exchange: default
-              topic: foo.rejects
-#    - csv:
-#        loader:
-#          file_path: output.csv
-#          delimiter: ','
-#          enclosure: '"'
-#          escape: '\'
-#      logger:
-#        channel: pipeline
-#        destinations:
-#          - elasticsearch:
-#              level: warning
-#              hosts:
-#                - elasticsearch.example.com:9200
+version: '2'
+satellites:
+  - name: 'Akeneo to CSV'
+    filesystem:
+      path: build/
+    composer:
+      require:
+        - "php-etl/pipeline:^0.3"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.2"
+        - "php-etl/rabbitmq-flow:^0.1"
+        - "akeneo/api-php-client-ee"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: productModel
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '>', value: 70, scope: ecommerce }
+              - { field: completeness, operator: '<', value: 85, scope: ecommerce }
+              - { field: categories, operator: IN, value: winter_collection }
+              - { field: family, operator: IN, value: [ camcorders, digital_cameras ] }
+          client:
+            api_url: '@=env("AKENEO_URL")'
+            client_id: '@=env("AKENEO_CLIENT_ID")'
+            secret: '@=env("AKENEO_CLIENT_SECRET")'
+            username: '@=env("AKENEO_USERNAME")'
+            password: '@=env("AKENEO_PASSWORD")'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+            - rabbitmq:
+                host: rabbitmq.example.com
+                port: 5432
+                vhost: /
+                exchange: default
+                topic: foo.rejects
+      - fastmap:
+          map:
+            - field: '[sku]'
+              copy: '[sku]'
+            - field: '[title]'
+              expression: 'input["sku"] ~" | "~ input["name"]'
+            - field: '[name]'
+              copy: '[name]'
+            - field: '[staticValue]'
+              constant: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur mollis efficitur justo, id facilisis elit venenatis et. Sed fermentum posuere convallis. Phasellus lectus neque, bibendum sit amet enim imperdiet, dignissim blandit nisi. Donec nec neque nisi. Vivamus luctus facilisis nibh id rhoncus. Vestibulum eget facilisis tortor. Etiam at cursus enim, vitae mollis ex. Proin at velit at erat bibendum ultricies. Duis ut velit malesuada, placerat nisl a, ultrices tortor.'
+            - field: '[foo]'
+              expression: 'input'
+              map:
+                - field: '[bar]'
+                  copy: '[bar]'
+            - field: '[foo]'
+              expression: 'input'
+              list:
+                - field: '[bar]'
+                  copy: '[bar]'
+  #          - field: '[descriptions]'
+  #            class: 'Pipeline\Usage'
+  #            expression: 'input["foo"]'
+  #            object:
+  #              - field: 'usage'
+  #                expression: '"Usage: " ~ input["usage"]'
+  #              - field: 'warning'
+  #                copy: '[warning]'
+  #              - field: 'notice'
+  #                copy: '[notice]'
+  #          - field: '[messages]'
+  #            class: 'Foo\DTO\Messages'
+  #            expression: 'input'
+  #            collection:
+  #            - field: 'usage'
+  #              expression: '"Usage: " ~ input["usage"]'
+  #            - field: 'warning'
+  #              copy: '[warning]'
+  #            - field: 'notice'
+  #              copy: '[notice]'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+            - rabbitmq:
+                host: rabbitmq.example.com
+                port: 5432
+                vhost: /
+                exchange: default
+                topic: foo.rejects
+      - akeneo:
+          expression_language:
+            - 'Kiboko\Component\ArrayExpressionLanguage\ArrayExpressionLanguageProvider'
+          lookup:
+            conditional:
+              - condition: 'input["type"] === "pim_attribute_simpleselect"'
+                type: attributeOption
+                code: '@=input["code"]'
+                method: all
+                search:
+                  - { field: "attributeOption_attribute", operator: "=", value: '@=input["code"]' }
+                merge:
+                  map:
+                    - field: '[options]'
+                      expression: 'join(lookup, ",")'
+          client:
+            api_url: 'http://localhost:8080'
+            client_id: '1_3clz4rzonukgsgoscoc488w0c4k0so48o0owc0k0sc40wso08g'
+            secret: '9tw5v88wl1s8s4ws8wsgk08gwkoo484cwc4k00wwkwosgwow4'
+            username: 'proximis_3328'
+            password: '93b66a306'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+            - rabbitmq:
+                host: rabbitmq.example.com
+                port: 5432
+                vhost: /
+                exchange: default
+                topic: foo.rejects
+  #    - csv:
+  #        loader:
+  #          file_path: output.csv
+  #          delimiter: ','
+  #          enclosure: '"'
+  #          escape: '\'
+  #      logger:
+  #        channel: pipeline
+  #        destinations:
+  #          - elasticsearch:
+  #              level: warning
+  #              hosts:
+  #                - elasticsearch.example.com:9200

--- a/examples/filesystem/cli-pipeline-akeneo-to-custom/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-custom/satellite.yaml
@@ -1,143 +1,145 @@
-satellite:
-  filesystem:
-    path: build/
-  composer:
-    require:
-      - "php-etl/pipeline:^0.3"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.2"
-      - "php-etl/rabbitmq-flow:^0.1"
-      - "akeneo/api-php-client-ee"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-      - "monolog/monolog"
-      - "elasticsearch/elasticsearch"
-      - "symfony/dependency-injection:^5.2"
-  pipeline:
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '>', value: 70, scope: ecommerce }
-            - { field: completeness, operator: '<', value: 85, scope: ecommerce }
-            - { field: categories, operator: IN, value: winter_collection }
-            - { field: family, operator: IN, value: [ camcorders, digital_cameras ] }
-        client:
-          api_url: '@=env("AKENEO_URL")'
-          client_id: '@=env("AKENEO_CLIENT_ID")'
-          secret: '@=env("AKENEO_CLIENT_SECRET")'
-          username: '@=env("AKENEO_USERNAME")'
-          password: '@=env("AKENEO_PASSWORD")'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-#          - rabbitmq:
-#              host: rabbitmq.example.com
-#              port: 5432
-#              vhost: /
-#              exchange: default
-#              topic: foo.rejects
-#    - fastmap:
-#        expression_language:
-#          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-#        conditional:
-#          - condition: 'input["family"] === "clothing"'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#              - field: '[translations][en_US]'
-#                expression: 'input'
-#                map:
-#                  - field: '[name]'
-#                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[slug]'
-#                    expression: 'input["identifier"]'
-#                  - field: '[description]'
-#                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[composition]'
-#                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-#                  - field: '[wash_temperature]'
-#                    expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
-#                  - field: '[care_instructions]'
-#                    expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
-#                  - field: '[material]'
-#                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-#          - condition: 'input["family"] === "led_tvs"'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#              - field: '[translations][en_US]'
-#                expression: 'input'
-#                map:
-#                  - field: '[name]'
-#                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[slug]'
-#                    expression: 'input["identifier"]'
-#                  - field: '[description]'
-#                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-#          - condition: 'input["family"] === "accessories"'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#              - field: '[translations][en_US]'
-#                expression: 'input'
-#                map:
-#                  - field: '[name]'
-#                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[slug]'
-#                    expression: 'input["identifier"]'
-#                  - field: '[composition]'
-#                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-#                  - field: '[material]'
-#                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-#          - condition: 'true'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#      logger:
-#        channel: pipeline
-#        destinations:
-#          - elasticsearch:
-#              level: warning
-#              hosts:
-#                - elasticsearch.example.com:9200
-#      rejection:
-#        destinations:
-#          - rabbitmq:
-#              host: rabbitmq.example.com
-#              port: 5432
-#              vhost: /
-#              exchange: default
-#              topic: foo.rejects
-#    - custom:
-#        loader:
-#          use: 'Pipeline\Foo'
-#          parameters:
-#            baz: '%env(PATH)%'
-#          services:
-#            Pipeline\Foo:
-#              arguments:
-#                - 'foo'
-#                - '@bar'
-##              calls:
-##                - setLogger: ['@logger']
-#            bar:
-#              class: Pipeline\Bar
+version: '2'
+satellites:
+  - name: 'Akeneo to custom pipeline'
+    filesystem:
+      path: build/
+    composer:
+      require:
+        - "php-etl/pipeline:^0.3"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.2"
+        - "php-etl/rabbitmq-flow:^0.1"
+        - "akeneo/api-php-client-ee"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+        - "monolog/monolog"
+        - "elasticsearch/elasticsearch"
+        - "symfony/dependency-injection:^5.2"
+    pipeline:
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '>', value: 70, scope: ecommerce }
+              - { field: completeness, operator: '<', value: 85, scope: ecommerce }
+              - { field: categories, operator: IN, value: winter_collection }
+              - { field: family, operator: IN, value: [ camcorders, digital_cameras ] }
+          client:
+            api_url: '@=env("AKENEO_URL")'
+            client_id: '@=env("AKENEO_CLIENT_ID")'
+            secret: '@=env("AKENEO_CLIENT_SECRET")'
+            username: '@=env("AKENEO_USERNAME")'
+            password: '@=env("AKENEO_PASSWORD")'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+  #          - rabbitmq:
+  #              host: rabbitmq.example.com
+  #              port: 5432
+  #              vhost: /
+  #              exchange: default
+  #              topic: foo.rejects
+  #    - fastmap:
+  #        expression_language:
+  #          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+  #        conditional:
+  #          - condition: 'input["family"] === "clothing"'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #              - field: '[translations][en_US]'
+  #                expression: 'input'
+  #                map:
+  #                  - field: '[name]'
+  #                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[slug]'
+  #                    expression: 'input["identifier"]'
+  #                  - field: '[description]'
+  #                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[composition]'
+  #                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+  #                  - field: '[wash_temperature]'
+  #                    expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
+  #                  - field: '[care_instructions]'
+  #                    expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
+  #                  - field: '[material]'
+  #                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+  #          - condition: 'input["family"] === "led_tvs"'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #              - field: '[translations][en_US]'
+  #                expression: 'input'
+  #                map:
+  #                  - field: '[name]'
+  #                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[slug]'
+  #                    expression: 'input["identifier"]'
+  #                  - field: '[description]'
+  #                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+  #          - condition: 'input["family"] === "accessories"'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #              - field: '[translations][en_US]'
+  #                expression: 'input'
+  #                map:
+  #                  - field: '[name]'
+  #                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[slug]'
+  #                    expression: 'input["identifier"]'
+  #                  - field: '[composition]'
+  #                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+  #                  - field: '[material]'
+  #                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+  #          - condition: 'true'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #      logger:
+  #        channel: pipeline
+  #        destinations:
+  #          - elasticsearch:
+  #              level: warning
+  #              hosts:
+  #                - elasticsearch.example.com:9200
+  #      rejection:
+  #        destinations:
+  #          - rabbitmq:
+  #              host: rabbitmq.example.com
+  #              port: 5432
+  #              vhost: /
+  #              exchange: default
+  #              topic: foo.rejects
+  #    - custom:
+  #        loader:
+  #          use: 'Pipeline\Foo'
+  #          parameters:
+  #            baz: '%env(PATH)%'
+  #          services:
+  #            Pipeline\Foo:
+  #              arguments:
+  #                - 'foo'
+  #                - '@bar'
+  ##              calls:
+  ##                - setLogger: ['@logger']
+  #            bar:
+  #              class: Pipeline\Bar

--- a/examples/filesystem/cli-pipeline-akeneo-to-ftp/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-ftp/satellite.yaml
@@ -1,70 +1,72 @@
-satellite:
-#  docker:
-#    from: php:8.0-cli-alpine
-#    workdir: /var/www/html
-#    tags:
-#      - kiboko/satellite:foo
-#      - kiboko/satellite:bar
-  filesystem:
-    path: build
-  composer:
-#    from_local: true
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\AkeneoToSylius\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.3.0"
-      - "php-etl/fast-map:^0.2.0"
-      - "akeneo/api-php-client-ee"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    expression_language:
-      - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-        client:
-          api_url: 'http://demo.akeneo.com/'
-          client_id: 5_40tp8kg20iww4g4o8c04kww4g48gg04o0co844c8gg044kwcoo
-          secret: 66csny0qiygwk08g8cowsgos40wg4c80kckwkwc8w0w0gg8s84
-          username: kiboko_8970
-          password: 0b98df436
-    - fastmap:
-        map:
-          - field: '[image]'
-            expression: 'attribute(input["values"]["image"])'
-    - akeneo:
-        lookup:
-          type: productMediaFile
-          method: download
-          code: '@=input["image"]'
-          merge:
-            map:
-              - field: "[image_file]"
-                expression: 'temporaryFile(lookup)'
-        client:
-          api_url: 'http://demo.akeneo.com/'
-          client_id: 5_40tp8kg20iww4g4o8c04kww4g48gg04o0co844c8gg044kwcoo
-          secret: 66csny0qiygwk08g8cowsgos40wg4c80kckwkwc8w0w0gg8s84
-          username: kiboko_8970
-          password: 0b98df436
-    - ftp:
-        expression_language:
-          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-        loader:
-          servers:
-            - host: localhost
-              port: 21
-              username: username
-              password: password
-              base_path: /my/path
-          put:
-            - path: '@=input["image"]'
-              content: '@=input["image_file"]'
-              mode: '0755'
-              if: '@=input["image"] !== null'
+version: '2'
+satellites:
+  - name: 'Akeneo to FTP'
+  #  docker:
+  #    from: php:8.0-cli-alpine
+  #    workdir: /var/www/html
+  #    tags:
+  #      - kiboko/satellite:foo
+  #      - kiboko/satellite:bar
+    filesystem:
+      path: build
+    composer:
+  #    from_local: true
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\AkeneoToSylius\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.3.0"
+        - "php-etl/fast-map:^0.2.0"
+        - "akeneo/api-php-client-ee"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      expression_language:
+        - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+          client:
+            api_url: 'http://demo.akeneo.com/'
+            client_id: 5_40tp8kg20iww4g4o8c04kww4g48gg04o0co844c8gg044kwcoo
+            secret: 66csny0qiygwk08g8cowsgos40wg4c80kckwkwc8w0w0gg8s84
+            username: kiboko_8970
+            password: 0b98df436
+      - fastmap:
+          map:
+            - field: '[image]'
+              expression: 'attribute(input["values"]["image"])'
+      - akeneo:
+          lookup:
+            type: productMediaFile
+            method: download
+            code: '@=input["image"]'
+            merge:
+              map:
+                - field: "[image_file]"
+                  expression: 'temporaryFile(lookup)'
+          client:
+            api_url: 'http://demo.akeneo.com/'
+            client_id: 5_40tp8kg20iww4g4o8c04kww4g48gg04o0co844c8gg044kwcoo
+            secret: 66csny0qiygwk08g8cowsgos40wg4c80kckwkwc8w0w0gg8s84
+            username: kiboko_8970
+            password: 0b98df436
+      - ftp:
+          expression_language:
+            - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+          loader:
+            servers:
+              - host: localhost
+                port: 21
+                username: username
+                password: password
+                base_path: /my/path
+            put:
+              - path: '@=input["image"]'
+                content: '@=input["image_file"]'
+                mode: '0755'
+                if: '@=input["image"] !== null'

--- a/examples/filesystem/cli-pipeline-akeneo-to-json-stream-stdout/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-json-stream-stdout/satellite.yaml
@@ -1,69 +1,71 @@
-satellite:
-#  docker:
-#    from: php:8.0-cli-alpine
-#    workdir: /var/www/html
-#    tags:
-#      - kiboko/satellite:akeneo-to-json-stream-stdout
-  filesystem:
-    path: build/
-  composer:
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.2"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.1"
-      - "akeneo/api-php-client-ee"
-      - "diglin/sylius-api-php-client"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '=', value: 100, scope: ecommerce }
-        client:
-          api_url: 'http://akeneo.example.com'
-          client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
-          secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
-          username: 'sylius_7380'
-          password: 56e94b109
-        logger:
-          channel: pipeline
-          destinations:
+version: '2'
+satellites:
+  - name: 'Akeneo to stdout'
+  #  docker:
+  #    from: php:8.0-cli-alpine
+  #    workdir: /var/www/html
+  #    tags:
+  #      - kiboko/satellite:akeneo-to-json-stream-stdout
+    filesystem:
+      path: build/
+    composer:
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.2"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.1"
+        - "akeneo/api-php-client-ee"
+        - "diglin/sylius-api-php-client"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '=', value: 100, scope: ecommerce }
+          client:
+            api_url: 'http://akeneo.example.com'
+            client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
+            secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
+            username: 'sylius_7380'
+            password: 56e94b109
+          logger:
+            channel: pipeline
+            destinations:
+              - elasticsearch:
+                  level: warning
+                  hosts:
+                    - elasticsearch.example.com:9200
+      - fastmap:
+          expression_language:
+            - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+          map:
+            - field: '[code]'
+              copy: '[identifier]'
+            - field: '[translations][en_US]'
+              expression: 'input'
+              map:
+                - field: '[name]'
+                  expression: 'input["identifier"] ~" | "~ attribute(input["values"]["variation_name"], locale("en_US"), scope(null, "ecommerce"))'
+                - field: '[slug]'
+                  expression: 'input["identifier"]'
+                - field: '[description]'
+                  expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+          logger:
+            channel: pipeline
+            destinations:
             - elasticsearch:
                 level: warning
                 hosts:
                   - elasticsearch.example.com:9200
-    - fastmap:
-        expression_language:
-          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-        map:
-          - field: '[code]'
-            copy: '[identifier]'
-          - field: '[translations][en_US]'
-            expression: 'input'
-            map:
-              - field: '[name]'
-                expression: 'input["identifier"] ~" | "~ attribute(input["values"]["variation_name"], locale("en_US"), scope(null, "ecommerce"))'
-              - field: '[slug]'
-                expression: 'input["identifier"]'
-              - field: '[description]'
-                expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-        logger:
-          channel: pipeline
-          destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - stream:
-        loader:
-          destination: stdout
+      - stream:
+          loader:
+            destination: stdout

--- a/examples/filesystem/cli-pipeline-akeneo-to-json-stream-stdout/satellite2.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-json-stream-stdout/satellite2.yaml
@@ -26,6 +26,3 @@ satellite:
           extractor:
             type: product
             method:
-
-
-

--- a/examples/filesystem/cli-pipeline-akeneo-to-stream-stdout-batched/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-stream-stdout-batched/satellite.yaml
@@ -106,13 +106,13 @@ satellites:
                   copy: '[identifier]'
                 - field: '[family]'
                   copy: '[family]'
-        logger:
-          channel: pipeline
-          destinations:
-            - elasticsearch:
-                level: warning
-                hosts:
-                  - elasticsearch.example.com:9200
+          logger:
+            channel: pipeline
+            destinations:
+              - elasticsearch:
+                  level: warning
+                  hosts:
+                    - elasticsearch.example.com:9200
       - batch:
           merge:
             size: 10

--- a/examples/filesystem/cli-pipeline-akeneo-to-stream-stdout-batched/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-stream-stdout-batched/satellite.yaml
@@ -1,37 +1,111 @@
-satellite:
-#  docker:
-#    from: php:8.0-cli-alpine
-#    workdir: /var/www/html
-#    tags:
-#      - kiboko/satellite:akeneo-to-stream-stdout
-  filesystem:
-    path: build
-  composer:
-    require:
-      - "php-etl/pipeline:^0.3"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.2"
-      - "akeneo/api-php-client-ee"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-      - "monolog/monolog"
-      - "elasticsearch/elasticsearch"
-  pipeline:
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '=', value: 100, scope: ecommerce }
-        client:
-          api_url: 'https://unlock-hippopotamus.demo.cloud.akeneo.com'
-          client_id: '5_2hogwrsqgj40owc8c8sw0swwwos80ccgkck84kok8kwkwswowk'
-          secret: '2pjdo95m1i0w8sw0wowowgcs4wgk8g0g4co4gw0wc88w8osk8'
-          username: 'sylius_3225'
-          password: 'ad6893ba0'
+version: '2'
+satellites:
+  - name: 'Akeneo to stdout in batch'
+  #  docker:
+  #    from: php:8.0-cli-alpine
+  #    workdir: /var/www/html
+  #    tags:
+  #      - kiboko/satellite:akeneo-to-stream-stdout
+    filesystem:
+      path: build
+    composer:
+      require:
+        - "php-etl/pipeline:^0.3"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.2"
+        - "akeneo/api-php-client-ee"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+        - "monolog/monolog"
+        - "elasticsearch/elasticsearch"
+    pipeline:
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '=', value: 100, scope: ecommerce }
+          client:
+            api_url: 'https://unlock-hippopotamus.demo.cloud.akeneo.com'
+            client_id: '5_2hogwrsqgj40owc8c8sw0swwwos80ccgkck84kok8kwkwswowk'
+            secret: '2pjdo95m1i0w8sw0wowowgcs4wgk8g0g4co4gw0wc88w8osk8'
+            username: 'sylius_3225'
+            password: 'ad6893ba0'
+          logger:
+            channel: pipeline
+            destinations:
+              - elasticsearch:
+                  level: warning
+                  hosts:
+                    - elasticsearch.example.com:9200
+      - fastmap:
+          expression_language:
+            - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+          conditional:
+            - condition: 'input["family"] === "clothing"'
+              map:
+                - field: '[code]'
+                  copy: '[identifier]'
+                - field: '[family]'
+                  copy: '[family]'
+                - field: '[translations][en_US]'
+                  expression: 'input'
+                  map:
+                    - field: '[name]'
+                      expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[slug]'
+                      expression: 'input["identifier"]'
+                    - field: '[description]'
+                      expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[composition]'
+                      expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+                    - field: '[wash_temperature]'
+                      expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
+                    - field: '[care_instructions]'
+                      expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
+                    - field: '[material]'
+                      expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+            - condition: 'input["family"] === "led_tvs"'
+              map:
+                - field: '[code]'
+                  copy: '[identifier]'
+                - field: '[family]'
+                  copy: '[family]'
+                - field: '[translations][en_US]'
+                  expression: 'input'
+                  map:
+                    - field: '[name]'
+                      expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[slug]'
+                      expression: 'input["identifier"]'
+                    - field: '[description]'
+                      expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+            - condition: 'input["family"] === "accessories"'
+              map:
+                - field: '[code]'
+                  copy: '[identifier]'
+                - field: '[family]'
+                  copy: '[family]'
+                - field: '[translations][en_US]'
+                  expression: 'input'
+                  map:
+                    - field: '[name]'
+                      expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[slug]'
+                      expression: 'input["identifier"]'
+                    - field: '[composition]'
+                      expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+                    - field: '[material]'
+                      expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+            - condition: 'true'
+              map:
+                - field: '[code]'
+                  copy: '[identifier]'
+                - field: '[family]'
+                  copy: '[family]'
         logger:
           channel: pipeline
           destinations:
@@ -39,88 +113,16 @@ satellite:
                 level: warning
                 hosts:
                   - elasticsearch.example.com:9200
-    - fastmap:
-        expression_language:
-          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-        conditional:
-          - condition: 'input["family"] === "clothing"'
-            map:
-              - field: '[code]'
-                copy: '[identifier]'
-              - field: '[family]'
-                copy: '[family]'
-              - field: '[translations][en_US]'
-                expression: 'input'
-                map:
-                  - field: '[name]'
-                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[slug]'
-                    expression: 'input["identifier"]'
-                  - field: '[description]'
-                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[composition]'
-                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-                  - field: '[wash_temperature]'
-                    expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
-                  - field: '[care_instructions]'
-                    expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
-                  - field: '[material]'
-                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-          - condition: 'input["family"] === "led_tvs"'
-            map:
-              - field: '[code]'
-                copy: '[identifier]'
-              - field: '[family]'
-                copy: '[family]'
-              - field: '[translations][en_US]'
-                expression: 'input'
-                map:
-                  - field: '[name]'
-                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[slug]'
-                    expression: 'input["identifier"]'
-                  - field: '[description]'
-                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-          - condition: 'input["family"] === "accessories"'
-            map:
-              - field: '[code]'
-                copy: '[identifier]'
-              - field: '[family]'
-                copy: '[family]'
-              - field: '[translations][en_US]'
-                expression: 'input'
-                map:
-                  - field: '[name]'
-                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[slug]'
-                    expression: 'input["identifier"]'
-                  - field: '[composition]'
-                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-                  - field: '[material]'
-                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-          - condition: 'true'
-            map:
-              - field: '[code]'
-                copy: '[identifier]'
-              - field: '[family]'
-                copy: '[family]'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - batch:
-        merge:
-          size: 10
-    - stream:
-        loader:
-          destination: 'stdout'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
+      - batch:
+          merge:
+            size: 10
+      - stream:
+          loader:
+            destination: 'stdout'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200

--- a/examples/filesystem/cli-pipeline-akeneo-to-sylius/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-to-sylius/satellite.yaml
@@ -1,142 +1,144 @@
-satellite:
-#  docker:
-#    from: php:8.0-cli-alpine
-#    workdir: /var/www/html
-#    tags:
-#      - kiboko/satellite:akeneo-to-sylius
-  filesystem:
-    path: build
-  composer:
-    require:
-      - "php-etl/pipeline:^0.3"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.2"
-      - "akeneo/api-php-client-ee"
-      - "diglin/sylius-api-php-client"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-      - "monolog/monolog"
-      - "elasticsearch/elasticsearch"
-  pipeline:
-    steps:
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '=', value: 100, scope: ecommerce }
-        client:
-          api_url: 'https://unlock-hippopotamus.demo.cloud.akeneo.com'
-          client_id: '5_2hogwrsqgj40owc8c8sw0swwwos80ccgkck84kok8kwkwswowk'
-          secret: '2pjdo95m1i0w8sw0wowowgcs4wgk8g0g4co4gw0wc88w8osk8'
-          username: 'sylius_3225'
-          password: 'ad6893ba0'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - fastmap:
-        expression_language:
-          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+version: '2'
+satellites:
+  - name: 'Akeneo to Sylius'
+  #  docker:
+  #    from: php:8.0-cli-alpine
+  #    workdir: /var/www/html
+  #    tags:
+  #      - kiboko/satellite:akeneo-to-sylius
+    filesystem:
+      path: build
+    composer:
+      require:
+        - "php-etl/pipeline:^0.3"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.2"
+        - "akeneo/api-php-client-ee"
+        - "diglin/sylius-api-php-client"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+        - "monolog/monolog"
+        - "elasticsearch/elasticsearch"
+    pipeline:
+      steps:
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '=', value: 100, scope: ecommerce }
+          client:
+            api_url: 'https://unlock-hippopotamus.demo.cloud.akeneo.com'
+            client_id: '5_2hogwrsqgj40owc8c8sw0swwwos80ccgkck84kok8kwkwswowk'
+            secret: '2pjdo95m1i0w8sw0wowowgcs4wgk8g0g4co4gw0wc88w8osk8'
+            username: 'sylius_3225'
+            password: 'ad6893ba0'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - fastmap:
+          expression_language:
+            - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
 
-        conditional:
-          - condition: 'input["family"] === "clothing"'
-            map:
-              - field: '[code]'
-                copy: '[identifier]'
-              - field: '[family]'
-                copy: '[family]'
-              - field: '[translations][en_US]'
-                expression: 'input'
-                map:
-                  - field: '[name]'
-                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[slug]'
-                    expression: 'input["identifier"]'
-                  - field: '[description]'
-                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-                  - field: '[composition]'
-                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-                  - field: '[wash_temperature]'
-                    expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
-                  - field: '[care_instructions]'
-                    expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
-                  - field: '[material]'
-                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-#          - condition: 'input["family"] === "led_tvs"'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#              - field: '[translations][en_US]'
-#                expression: 'input'
-#                map:
-#                  - field: '[name]'
-#                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[slug]'
-#                    expression: 'input["identifier"]'
-#                  - field: '[description]'
-#                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
-#          - condition: 'input["family"] === "accessories"'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-#              - field: '[translations][en_US]'
-#                expression: 'input'
-#                map:
-#                  - field: '[name]'
-#                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
-#                  - field: '[slug]'
-#                    expression: 'input["identifier"]'
-#                  - field: '[composition]'
-#                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
-#                  - field: '[material]'
-#                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
-#          - condition: 'true'
-#            map:
-#              - field: '[code]'
-#                copy: '[identifier]'
-#              - field: '[family]'
-#                copy: '[family]'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - sylius:
-        loader:
-          type: products
-          method: create
-        client:
-          api_url: 'http://localhost'
-          client_id: '414yc7d9mnk044ko4wswgw80o8ssw80gssos488kk8ogss40ko'
-          secret: '4k8ee6n44m4gkkg0coc8o4w4coscw0w4cg0wg8sc0wsk0sw8gs'
-          username: 'api'
-          password: 'sylius-api'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - stream:
-        loader:
-          destination: 'stdout'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
+          conditional:
+            - condition: 'input["family"] === "clothing"'
+              map:
+                - field: '[code]'
+                  copy: '[identifier]'
+                - field: '[family]'
+                  copy: '[family]'
+                - field: '[translations][en_US]'
+                  expression: 'input'
+                  map:
+                    - field: '[name]'
+                      expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[slug]'
+                      expression: 'input["identifier"]'
+                    - field: '[description]'
+                      expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+                    - field: '[composition]'
+                      expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+                    - field: '[wash_temperature]'
+                      expression: 'attribute(input["values"]["wash_temperature"], locale(null), scope(null))'
+                    - field: '[care_instructions]'
+                      expression: 'attribute(input["values"]["care_instructions"], locale(null), scope(null))'
+                    - field: '[material]'
+                      expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+  #          - condition: 'input["family"] === "led_tvs"'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #              - field: '[translations][en_US]'
+  #                expression: 'input'
+  #                map:
+  #                  - field: '[name]'
+  #                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[slug]'
+  #                    expression: 'input["identifier"]'
+  #                  - field: '[description]'
+  #                    expression: 'attribute(input["values"]["description"], locale("en_US"), scope("ecommerce"))'
+  #          - condition: 'input["family"] === "accessories"'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+  #              - field: '[translations][en_US]'
+  #                expression: 'input'
+  #                map:
+  #                  - field: '[name]'
+  #                    expression: 'attribute(input["values"]["variation_name"], locale("en_US"), scope("ecommerce"))'
+  #                  - field: '[slug]'
+  #                    expression: 'input["identifier"]'
+  #                  - field: '[composition]'
+  #                    expression: 'attribute(input["values"]["composition"], locale(null), scope(null))'
+  #                  - field: '[material]'
+  #                    expression: 'attribute(input["values"]["material"], locale(null), scope(null))'
+  #          - condition: 'true'
+  #            map:
+  #              - field: '[code]'
+  #                copy: '[identifier]'
+  #              - field: '[family]'
+  #                copy: '[family]'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - sylius:
+          loader:
+            type: products
+            method: create
+          client:
+            api_url: 'http://localhost'
+            client_id: '414yc7d9mnk044ko4wswgw80o8ssw80gssos488kk8ogss40ko'
+            secret: '4k8ee6n44m4gkkg0coc8o4w4coscw0w4cg0wg8sc0wsk0sw8gs'
+            username: 'api'
+            password: 'sylius-api'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - stream:
+          loader:
+            destination: 'stdout'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200

--- a/examples/filesystem/cli-pipeline-akeneo-with-fork/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-akeneo-with-fork/satellite.yaml
@@ -1,44 +1,46 @@
-satellite:
-  filesystem:
-    path: build
-  composer:
-    require:
-        - "php-etl/pipeline:^0.3"
-        - "php-etl/fast-map:^0.2"
-        - "akeneo/api-php-client-ee"
-        - "laminas/laminas-diactoros"
-        - "php-http/guzzle7-adapter"
-        - "php-etl/mapping-contracts:dev-fix-dependencies as 0.2.0"
-        - "monolog/monolog"
-        - "elasticsearch/elasticsearch"
+version: '2'
+satellites:
+  - name: 'Akeneo with fork'
+    filesystem:
+      path: build
+    composer:
+      require:
+          - "php-etl/pipeline:^0.3"
+          - "php-etl/fast-map:^0.2"
+          - "akeneo/api-php-client-ee"
+          - "laminas/laminas-diactoros"
+          - "php-http/guzzle7-adapter"
+          - "php-etl/mapping-contracts:dev-fix-dependencies as 0.2.0"
+          - "monolog/monolog"
+          - "elasticsearch/elasticsearch"
 
-  pipeline:
-    steps:
-      - akeneo:
-          enterprise: false
-          extractor:
-              type: product
-              method: all
-          client:
-              api_url: 'http://localhost:8080'
-              client_id: '1_1pfmqgqw53r4w4g0kscoc0wckkkco8swcoowk484840wco4koo'
-              secret: '11oo1el7nrn4o408kgokoccoswg4wgc4440w8w8sgsko84wssg'
-              username: 'proximis_7215'
-              password: '00e666b44'
-        logger:
-          channel: pipeline
-          destinations:
-            - elasticsearch:
-                level: notice
-                hosts:
-                  - 'http://localhost:9200'
-      - batch:
-          expression_language:
-          - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
-          fork:
-            foreach: '@=["Nom_produit", "coloris", "code_tfp"]'
-            do: '@={ code: input["identifier"], LCID: "fr_FR", attributeName: item, attributeValue: attribute(input["values"][item], locale("fr_FR", null)) }'
+    pipeline:
+      steps:
+        - akeneo:
+            enterprise: false
+            extractor:
+                type: product
+                method: all
+            client:
+                api_url: 'http://localhost:8080'
+                client_id: '1_1pfmqgqw53r4w4g0kscoc0wckkkco8swcoowk484840wco4koo'
+                secret: '11oo1el7nrn4o408kgokoccoswg4wgc4440w8w8sgsko84wssg'
+                username: 'proximis_7215'
+                password: '00e666b44'
+          logger:
+            channel: pipeline
+            destinations:
+              - elasticsearch:
+                  level: notice
+                  hosts:
+                    - 'http://localhost:9200'
+        - batch:
+            expression_language:
+            - 'Kiboko\Component\ExpressionLanguage\Akeneo\AkeneoFilterProvider'
+            fork:
+              foreach: '@=["Nom_produit", "coloris", "code_tfp"]'
+              do: '@={ code: input["identifier"], LCID: "fr_FR", attributeName: item, attributeValue: attribute(input["values"][item], locale("fr_FR", null)) }'
 
-      - stream:
-            loader:
-                destination: stdout
+        - stream:
+              loader:
+                  destination: stdout

--- a/examples/filesystem/cli-pipeline-csv-to-akeneo-with-sftp/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-csv-to-akeneo-with-sftp/satellite.yaml
@@ -1,107 +1,109 @@
-satellite:
+version: '2'
+satellites:
+  - name: 'CSV to Akeneo'
 #  docker:
 #    from: php:8.0-cli-alpine
 #    workdir: /var/www/html
 #    tags:
 #      - kiboko/satellite:akeneo-to-sylius
-  filesystem:
-    path: build/
-  composer:
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.2"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.1"
-      - "akeneo/api-php-client-ee"
-      - "diglin/sylius-api-php-client"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    steps:
-    - csv:
-        extractor:
-          file_path: 'foo.csv'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - fastmap:
-        map:
-        - field: '[identifier]'
-          copy: '[sku]'
-        - field: '[values]'
-          expression: 'input'
+    filesystem:
+      path: build/
+    composer:
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.2"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.1"
+        - "akeneo/api-php-client-ee"
+        - "diglin/sylius-api-php-client"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      steps:
+      - csv:
+          extractor:
+            file_path: 'foo.csv'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - fastmap:
           map:
-          - field: '[name]'
-            expression: '[ { name: input["name"], locale: null, scope: null } ]'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-          - kafka:
-              brokers:
-                - 'kafka.example.com:3200'
-              topics:
-                - 'lorem.ipsum'
-          - rabbitmq:
-              servers:
-                - host: 'rabbitmq.example.com'
-                  port: '1234'
-                  vhost: '/'
-              channels:
-                - 'lorem.ipsum'
-      state:
-        destinations:
-          - redis:
-              servers:
-                - host: 'redis.example.com'
-                  port: '1234'
-                  dbindex: 1
-                  timeout: 100
-          - memcached:
-              servers:
-                - host: 'memcached.example.com'
-                  port: '1234'
-                  timeout: 100
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '=', value: 100, scope: ecommerce }
-        client:
-          api_url: 'http://akeneo.example.com'
-          client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
-          secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
-          username: 'sylius_7380'
-          password: 56e94b109
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - stream:
-        loader:
-          destination: stderr
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
+          - field: '[identifier]'
+            copy: '[sku]'
+          - field: '[values]'
+            expression: 'input'
+            map:
+            - field: '[name]'
+              expression: '[ { name: input["name"], locale: null, scope: null } ]'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+            - kafka:
+                brokers:
+                  - 'kafka.example.com:3200'
+                topics:
+                  - 'lorem.ipsum'
+            - rabbitmq:
+                servers:
+                  - host: 'rabbitmq.example.com'
+                    port: '1234'
+                    vhost: '/'
+                channels:
+                  - 'lorem.ipsum'
+        state:
+          destinations:
+            - redis:
+                servers:
+                  - host: 'redis.example.com'
+                    port: '1234'
+                    dbindex: 1
+                    timeout: 100
+            - memcached:
+                servers:
+                  - host: 'memcached.example.com'
+                    port: '1234'
+                    timeout: 100
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '=', value: 100, scope: ecommerce }
+          client:
+            api_url: 'http://akeneo.example.com'
+            client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
+            secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
+            username: 'sylius_7380'
+            password: 56e94b109
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - stream:
+          loader:
+            destination: stderr
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200

--- a/examples/filesystem/cli-pipeline-csv-to-ldjson/satellite.yml
+++ b/examples/filesystem/cli-pipeline-csv-to-ldjson/satellite.yml
@@ -1,20 +1,21 @@
-satellite:
-  filesystem:
-    path: 'build/'
-  composer:
-    require:
-#      - php-etl/pipeline:^0.3.0
-#      - php-etl/bucket:^0.2.0
-#      - php-etl/csv-flow:^0.2.0
-#      - psr/log:^1.1
-  pipeline:
-    steps:
-      - csv:
-          extractor:
-            file_path: 'data/products.csv'
+version: '2'
+satellites:
+  - name: 'CSV to JSON'
+    filesystem:
+      path: 'build/'
+    composer:
+      require:
+  #      - php-etl/pipeline:^0.3.0
+  #      - php-etl/bucket:^0.2.0
+  #      - php-etl/csv-flow:^0.2.0
+  #      - psr/log:^1.1
+    pipeline:
+      steps:
+        - csv:
+            extractor:
+              file_path: 'data/products.csv'
 
-      - stream:
-          loader:
-            destination: 'stderr'
-            format: 'json'
-
+        - stream:
+            loader:
+              destination: 'stderr'
+              format: 'json'

--- a/examples/filesystem/cli-pipeline-custom-to-akeneo/satellite.yaml
+++ b/examples/filesystem/cli-pipeline-custom-to-akeneo/satellite.yaml
@@ -1,107 +1,109 @@
-satellite:
-#  docker:
-#    from: php:8.0-cli-alpine
-#    workdir: /var/www/html
-#    tags:
-#      - kiboko/satellite:akeneo-to-sylius
-  filesystem:
-    path: build/
-  composer:
-    autoload:
-      psr4:
-      - namespace: "Pipeline\\"
-        paths: [ "" ]
-    require:
-      - "php-etl/pipeline:^0.2"
-      - "php-etl/fast-map:^0.2"
-      - "php-etl/csv-flow:^0.1"
-      - "akeneo/api-php-client-ee"
-      - "diglin/sylius-api-php-client"
-      - "laminas/laminas-diactoros"
-      - "php-http/guzzle7-adapter"
-  pipeline:
-    steps:
-    - csv:
-        extractor:
-          file_path: 'foo.csv'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - fastmap:
-        map:
-        - field: '[identifier]'
-          copy: '[sku]'
-        - field: '[values]'
-          expression: 'input'
+version: '2'
+satellites:
+  - name: 'Custom pipeline to Akeneo'
+  #  docker:
+  #    from: php:8.0-cli-alpine
+  #    workdir: /var/www/html
+  #    tags:
+  #      - kiboko/satellite:akeneo-to-sylius
+    filesystem:
+      path: build/
+    composer:
+      autoload:
+        psr4:
+        - namespace: "Pipeline\\"
+          paths: [ "" ]
+      require:
+        - "php-etl/pipeline:^0.2"
+        - "php-etl/fast-map:^0.2"
+        - "php-etl/csv-flow:^0.1"
+        - "akeneo/api-php-client-ee"
+        - "diglin/sylius-api-php-client"
+        - "laminas/laminas-diactoros"
+        - "php-http/guzzle7-adapter"
+    pipeline:
+      steps:
+      - csv:
+          extractor:
+            file_path: 'foo.csv'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - fastmap:
           map:
-          - field: '[name]'
-            expression: '[ { name: input["name"], locale: null, scope: null } ]'
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-      rejection:
-        destinations:
-          - kafka:
-              brokers:
-                - 'kafka.example.com:3200'
-              topics:
-                - 'lorem.ipsum'
-          - rabbitmq:
-              servers:
-                - host: 'rabbitmq.example.com'
-                  port: '1234'
-                  vhost: '/'
-              channels:
-                - 'lorem.ipsum'
-      state:
-        destinations:
-          - redis:
-              servers:
-                - host: 'redis.example.com'
-                  port: '1234'
-                  dbindex: 1
-                  timeout: 100
-          - memcached:
-              servers:
-                - host: 'memcached.example.com'
-                  port: '1234'
-                  timeout: 100
-    - akeneo:
-        enterprise: true
-        extractor:
-          type: product
-          method: all
-          search:
-            - { field: enabled, operator: '=', value: true }
-            - { field: completeness, operator: '=', value: 100, scope: ecommerce }
-        client:
-          api_url: 'http://akeneo.example.com'
-          client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
-          secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
-          username: 'sylius_7380'
-          password: 56e94b109
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
-    - stream:
-        loader:
-          destination: stderr
-      logger:
-        channel: pipeline
-        destinations:
-          - elasticsearch:
-              level: warning
-              hosts:
-                - elasticsearch.example.com:9200
+          - field: '[identifier]'
+            copy: '[sku]'
+          - field: '[values]'
+            expression: 'input'
+            map:
+            - field: '[name]'
+              expression: '[ { name: input["name"], locale: null, scope: null } ]'
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+        rejection:
+          destinations:
+            - kafka:
+                brokers:
+                  - 'kafka.example.com:3200'
+                topics:
+                  - 'lorem.ipsum'
+            - rabbitmq:
+                servers:
+                  - host: 'rabbitmq.example.com'
+                    port: '1234'
+                    vhost: '/'
+                channels:
+                  - 'lorem.ipsum'
+        state:
+          destinations:
+            - redis:
+                servers:
+                  - host: 'redis.example.com'
+                    port: '1234'
+                    dbindex: 1
+                    timeout: 100
+            - memcached:
+                servers:
+                  - host: 'memcached.example.com'
+                    port: '1234'
+                    timeout: 100
+      - akeneo:
+          enterprise: true
+          extractor:
+            type: product
+            method: all
+            search:
+              - { field: enabled, operator: '=', value: true }
+              - { field: completeness, operator: '=', value: 100, scope: ecommerce }
+          client:
+            api_url: 'http://akeneo.example.com'
+            client_id: '1_4bp53pdh1zi8g88w8gw0888s8oo00g4g8wwg800swsc0wco8o0'
+            secret: 5pkxk7lhsycc404cs0kgg4gossww84sow0gk4kksckss4ggswo
+            username: 'sylius_7380'
+            password: 56e94b109
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200
+      - stream:
+          loader:
+            destination: stderr
+        logger:
+          channel: pipeline
+          destinations:
+            - elasticsearch:
+                level: warning
+                hosts:
+                  - elasticsearch.example.com:9200

--- a/examples/filesystem/cli-workflow-akeneo-to-sylius/satellite.yaml
+++ b/examples/filesystem/cli-workflow-akeneo-to-sylius/satellite.yaml
@@ -1,6 +1,6 @@
-#version: "0.3"
-satellite:
-#  akeneo_to_sylius:
+version: '2'
+satellites:
+  - name: 'Akeneo to Sylius'
     serverless:
       provider:
         name: "aws"


### PR DESCRIPTION
il faut migrer tous les fichiers d’exemple pour les passer sur le nouveau format sur php-etl/satellite
de
```
satellite:
  filesystem: ...
  composer: ...
  pipeline: ...
```
à
```
version: '2'
satellites:
  - name: "Lorem ipsum"
    filesystem: ...
    composer: ...
    pipeline: ...
```