### PR TITLE
Fixed the code return by the workflow builder

### DIFF
--- a/src/Builder/Workflow/WorkflowRuntime.php
+++ b/src/Builder/Workflow/WorkflowRuntime.php
@@ -18,11 +18,6 @@ final class WorkflowRuntime implements Builder
                     )
                 ),
                 new Node\Arg(
-                    value: new Node\Expr\New_(
-                        class: new Node\Name\FullyQualified('Kiboko\\Component\\Workflow\\Workflow'),
-                    ),
-                ),
-                new Node\Arg(
                     new Node\Expr\New_(
                         class: new Node\Name\FullyQualified('Kiboko\\Component\\Pipeline\\PipelineRunner'),
                         args: [


### PR DESCRIPTION
Suite au commit effectué sur ce package : https://github.com/php-etl/workflow-console-runtime/commit/93a2c48a6e80769e728636ae213ff915081acead, la classe  `Kiboko\\Component\\Runtime\\Workflow\\Console` ne prend plus que 2 paramètres
