### PR TITLE
clear vendors when composer.json is not valid,

### DIFF
--- a/src/Adapter/Composer.php
+++ b/src/Adapter/Composer.php
@@ -32,7 +32,7 @@ final class Composer
         });
 
         if (0 !== $process->getExitCode()) {
-            throw new \RuntimeException(sprintf('Process exited unexpectedly. %s', $process->getCommandLine()));
+            throw new ComposerFailureException($process->getCommandLine(), sprintf('Process exited unexpectedly with output: %s', $process->getErrorOutput()), $process->getExitCode());
         }
     }
 
@@ -86,14 +86,88 @@ final class Composer
         );
     }
 
+    private function clearVendor(): void
+    {
+        $iterator = new \AppendIterator();
+
+        try {
+            $iterator->append(new \GlobIterator($this->workdir.'/composer.*', \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::KEY_AS_PATHNAME));
+            $iterator->append(new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    $this->workdir.'/vendor',
+                    \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS
+                ),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            ));
+        } catch (\UnexpectedValueException $e) {
+            $this->logger->warning($e->getMessage());
+        }
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+    }
+
     public function init(string $name): void
     {
+        if (file_exists($this->workdir.'/composer.json')) {
+            if (filesize($this->workdir.'/composer.json') <= 2) {
+                $this->clearVendor();
+            } else {
+                try {
+                    $this->allowPlugins('php-http/discovery');
+
+                    return;
+                } catch (ComposerFailureException) {
+                    $this->clearVendor();
+                }
+            }
+        }
+
         $this->command(
             'composer',
             'init',
             '--no-interaction',
             sprintf('--name=%s', $name),
         );
+
+        $this->allowPlugins('php-http/discovery');
+    }
+
+    public function forcePlugins(string ...$plugins): void
+    {
+        foreach ($plugins as $packageName) {
+            $this->command(
+                'composer',
+                'config',
+                sprintf('allow-plugins.%s', $packageName),
+                'true',
+            );
+        }
+    }
+
+    public function allowPlugins(string ...$plugins): void
+    {
+        foreach ($plugins as $packageName) {
+            $this->command(
+                'composer',
+                'config',
+                sprintf('allow-plugins.%s', $packageName),
+                'true',
+            );
+        }
+    }
+
+    public function denyPlugins(string ...$plugins): void
+    {
+        foreach ($plugins as $packageName) {
+            $this->command(
+                'composer',
+                'config',
+                sprintf('allow-plugins.%s', $packageName),
+                'false',
+            );
+        }
     }
 
     /**

--- a/src/Adapter/Composer.php
+++ b/src/Adapter/Composer.php
@@ -104,7 +104,7 @@ final class Composer
         }
 
         foreach ($iterator as $file) {
-            $file->getType() === 'dir' ? rmdir($file->getPathname()) : unlink($file->getPathname());
+            'dir' === $file->getType() ? rmdir($file->getPathname()) : unlink($file->getPathname());
         }
     }
 
@@ -132,18 +132,6 @@ final class Composer
         );
 
         $this->allowPlugins('php-http/discovery');
-    }
-
-    public function forcePlugins(string ...$plugins): void
-    {
-        foreach ($plugins as $packageName) {
-            $this->command(
-                'composer',
-                'config',
-                sprintf('allow-plugins.%s', $packageName),
-                'true',
-            );
-        }
     }
 
     public function allowPlugins(string ...$plugins): void

--- a/src/Adapter/Composer.php
+++ b/src/Adapter/Composer.php
@@ -104,7 +104,7 @@ final class Composer
         }
 
         foreach ($iterator as $file) {
-            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+            $file->getType() === 'dir' ? rmdir($file->getPathname()) : unlink($file->getPathname());
         }
     }
 

--- a/src/Adapter/ComposerFailureException.php
+++ b/src/Adapter/ComposerFailureException.php
@@ -6,7 +6,7 @@ namespace Kiboko\Component\Satellite\Adapter;
 
 final class ComposerFailureException extends \RuntimeException
 {
-    public function __construct(private readonly string $command = '', string $message = '', int $code = 0, ?\Throwable $previous = null)
+    public function __construct(private readonly string $command = '', string $message = '', int $code = 0, null|\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Adapter/ComposerFailureException.php
+++ b/src/Adapter/ComposerFailureException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Adapter;
+
+final class ComposerFailureException extends \RuntimeException
+{
+    public function __construct(private readonly string $command = '', string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getCommand(): string
+    {
+        return $this->command;
+    }
+}

--- a/src/Console/Command/PipelineRunCommand.php
+++ b/src/Console/Command/PipelineRunCommand.php
@@ -65,6 +65,11 @@ final class PipelineRunCommand extends Console\Command\Command
             ),
         );
 
+        if (!file_exists('pipeline.php')) {
+            $style->error('The provided path does not contain one single pipeline, did you mean to run "run:workflow"?');
+
+            return \Symfony\Component\Console\Command\Command::FAILURE;
+        }
         /** @var callable(runtime: PipelineRuntimeInterface): \Runtime $pipeline */
         $pipeline = include 'pipeline.php';
 

--- a/src/Console/Command/WorkflowRunCommand.php
+++ b/src/Console/Command/WorkflowRunCommand.php
@@ -61,6 +61,11 @@ final class WorkflowRunCommand extends Console\Command\Command
             new \Kiboko\Component\Pipeline\PipelineRunner(new \Psr\Log\NullLogger()),
         );
 
+        if (!file_exists('workflow.php')) {
+            $style->error('The provided path does not contain a workflow, did you mean to run "run:pipeline"?');
+
+            return \Symfony\Component\Console\Command\Command::FAILURE;
+        }
         /** @var callable(runtime: WorkflowRuntimeInterface): \Runtime $workflow */
         $workflow = include 'workflow.php';
 


### PR DESCRIPTION
clear vendors when composer.json is not valid (https://github.com/php-etl/satellite/issues/99),
allow php-http/discovery plugin,
tell the user when there is no pipeline.php or workflow.php (https://github.com/php-etl/satellite/issues/104)