### PR TITLE
Started to create classes to send workflow configurations to the cloud

### DIFF
--- a/bin/cloud
+++ b/bin/cloud
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 
-if (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
+if (file_exists(getcwd() . '/vendor/autoload.php')) {
+    require getcwd() . '/vendor/autoload.php';
+} else if (file_exists(__DIR__ . '/../../../../vendor/autoload.php')) {
     require __DIR__ . '/../../../../vendor/autoload.php';
 } else if (file_exists(__DIR__ . '/../../../vendor/autoload.php')) {
     require __DIR__ . '/../../../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/deprecation-contracts": "*",
         "react/child-process": "^0.7",
         "react/async": "^4.1",
-        "react/promise-timer": "^1.10"
+        "react/promise-timer": "^1.10",
+        "symfony/http-client": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0",
@@ -50,7 +51,6 @@
         "rector/rector": "^0.15",
         "php-etl/phpunit-extension": "0.7.*",
         "mikey179/vfsstream": "^1.6",
-        "symfony/http-client": "^6.3",
         "friendsofphp/php-cs-fixer": "^3.38"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62f878223223ac87d5e0ffa323666abc",
+    "content-hash": "546a5d2a5f2a1ec065e2ec9b2060f6fa",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1535,16 +1535,16 @@
         },
         {
             "name": "php-etl/gyroscops-api-client",
-            "version": "v0.3.0",
+            "version": "v0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-etl/gyroscops-api-client.git",
-                "reference": "aebd5ea11b069877f2f4e0b5d0d2a3d9343cf124"
+                "reference": "9583c6e883fe246b72fa420211b6b20df9c4a2ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-etl/gyroscops-api-client/zipball/aebd5ea11b069877f2f4e0b5d0d2a3d9343cf124",
-                "reference": "aebd5ea11b069877f2f4e0b5d0d2a3d9343cf124",
+                "url": "https://api.github.com/repos/php-etl/gyroscops-api-client/zipball/9583c6e883fe246b72fa420211b6b20df9c4a2ab",
+                "reference": "9583c6e883fe246b72fa420211b6b20df9c4a2ab",
                 "shasum": ""
             },
             "require": {
@@ -1552,9 +1552,9 @@
                 "php": "^8.2"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11",
+                "friendsofphp/php-cs-fixer": "^3.38",
                 "jane-php/open-api-3": "^7.4",
-                "rector/rector": "^0.15.19"
+                "rector/rector": "^0.15"
             },
             "type": "library",
             "extra": {
@@ -1584,9 +1584,9 @@
             "description": "This package provides Jane-PHP generated API models and client based on the OpenAPI specification.",
             "support": {
                 "issues": "https://github.com/php-etl/gyroscops-api-client/issues",
-                "source": "https://github.com/php-etl/gyroscops-api-client/tree/v0.3.0"
+                "source": "https://github.com/php-etl/gyroscops-api-client/tree/v0.3.1"
             },
-            "time": "2023-10-24T07:53:14+00:00"
+            "time": "2024-01-15T14:02:55+00:00"
         },
         {
             "name": "php-etl/packaging",
@@ -5285,6 +5285,176 @@
             "time": "2023-09-26T12:56:25+00:00"
         },
         {
+            "name": "symfony/http-client",
+            "version": "v6.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/0314e2d49939a9831929d6fc81c01c6df137fd0a",
+                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "^3",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.3"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/amp": "^2.5",
+                "amphp/http-client": "^4.2.1",
+                "amphp/http-tunnel": "^1.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v6.3.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-06T18:31:59+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654",
+                "reference": "1ee70e699b41909c209a0c930f11034b93578654",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-30T20:28:31+00:00"
+        },
+        {
             "name": "symfony/options-resolver",
             "version": "v6.3.0",
             "source": {
@@ -8812,176 +8982,6 @@
                 }
             ],
             "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/http-client",
-            "version": "v6.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-client.git",
-                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/0314e2d49939a9831929d6fc81c01c6df137fd0a",
-                "reference": "0314e2d49939a9831929d6fc81c01c6df137fd0a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/log": "^1|^2|^3",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/http-client-contracts": "^3",
-                "symfony/service-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "php-http/discovery": "<1.15",
-                "symfony/http-foundation": "<6.3"
-            },
-            "provide": {
-                "php-http/async-client-implementation": "*",
-                "php-http/client-implementation": "*",
-                "psr/http-client-implementation": "1.0",
-                "symfony/http-client-implementation": "3.0"
-            },
-            "require-dev": {
-                "amphp/amp": "^2.5",
-                "amphp/http-client": "^4.2.1",
-                "amphp/http-tunnel": "^1.0",
-                "amphp/socket": "^1.1",
-                "guzzlehttp/promises": "^1.4",
-                "nyholm/psr7": "^1.0",
-                "php-http/httplug": "^1.0|^2.0",
-                "psr/http-client": "^1.0",
-                "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/http-kernel": "^5.4|^6.0",
-                "symfony/process": "^5.4|^6.0",
-                "symfony/stopwatch": "^5.4|^6.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\HttpClient\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "http"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.3.8"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-11-06T18:31:59+00:00"
-        },
-        {
-            "name": "symfony/http-client-contracts",
-            "version": "v3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "1ee70e699b41909c209a0c930f11034b93578654"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/1ee70e699b41909c209a0c930f11034b93578654",
-                "reference": "1ee70e699b41909c209a0c930f11034b93578654",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\HttpClient\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to HTTP clients",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/src/Action/Action.php
+++ b/src/Action/Action.php
@@ -33,7 +33,7 @@ final readonly class Action
             $logger = $compiled->getBuilder()->getNode();
         } else {
             $logger = new Node\Expr\New_(
-                new Node\Name\FullyQualified(\Psr\Log\NullLogger::class),
+                new Node\Name\FullyQualified('Psr\\Log\\NullLogger'),
             );
         }
 

--- a/src/Builder/API/APIRuntime.php
+++ b/src/Builder/API/APIRuntime.php
@@ -23,7 +23,7 @@ final class APIRuntime
                                     args: [
                                         new Node\Arg(
                                             value: new Node\Expr\New_(
-                                                class: new Node\Name\FullyQualified('Ps\\Log\\NullLogger')
+                                                class: new Node\Name\FullyQualified('Psr\\Log\\NullLogger')
                                             )
                                         ),
                                     ]

--- a/src/Builder/API/APIRuntime.php
+++ b/src/Builder/API/APIRuntime.php
@@ -23,7 +23,7 @@ final class APIRuntime
                                     args: [
                                         new Node\Arg(
                                             value: new Node\Expr\New_(
-                                                class: new Node\Name\FullyQualified(\Psr\Log\NullLogger::class)
+                                                class: new Node\Name\FullyQualified('Ps\\Log\\NullLogger')
                                             )
                                         ),
                                     ]

--- a/src/Builder/Hook/HookRuntime.php
+++ b/src/Builder/Hook/HookRuntime.php
@@ -23,7 +23,7 @@ final class HookRuntime
                                     args: [
                                         new Node\Arg(
                                             value: new Node\Expr\New_(
-                                                class: new Node\Name\FullyQualified(\Psr\Log\NullLogger::class)
+                                                class: new Node\Name\FullyQualified('Psr\\Log\\NullLogger')
                                             )
                                         ),
                                     ]

--- a/src/Builder/Pipeline/ConsoleRuntime.php
+++ b/src/Builder/Pipeline/ConsoleRuntime.php
@@ -16,7 +16,7 @@ final class ConsoleRuntime implements Builder
             args: [
                 new Node\Arg(
                     value: new Node\Expr\New_(
-                        class: new Node\Name\FullyQualified(\Symfony\Component\Console\Output\ConsoleOutput::class),
+                        class: new Node\Name\FullyQualified('Symfony\\Component\\Console\\Output\\ConsoleOutput'),
                     )
                 ),
                 new Node\Arg(
@@ -29,7 +29,7 @@ final class ConsoleRuntime implements Builder
                                     args: [
                                         new Node\Arg(
                                             value: new Node\Expr\New_(
-                                                class: new Node\Name\FullyQualified(\Psr\Log\NullLogger::class),
+                                                class: new Node\Name\FullyQualified('Psr\\Log\\NullLogger'),
                                             )
                                         ),
                                     ],

--- a/src/Builder/Workflow/WorkflowRuntime.php
+++ b/src/Builder/Workflow/WorkflowRuntime.php
@@ -16,7 +16,7 @@ final class WorkflowRuntime implements Builder
             args: [
                 new Node\Arg(
                     value: new Node\Expr\New_(
-                        class: new Node\Name\FullyQualified(\Symfony\Component\Console\Output\ConsoleOutput::class),
+                        class: new Node\Name\FullyQualified('Symfony\\Component\\Console\\Output\\ConsoleOutput'),
                     )
                 ),
                 new Node\Arg(
@@ -25,7 +25,7 @@ final class WorkflowRuntime implements Builder
                         args: [
                             new Node\Arg(
                                 value: new Node\Expr\New_(
-                                    class: new Node\Name\FullyQualified(\Psr\Log\NullLogger::class),
+                                    class: new Node\Name\FullyQualified('Psr\\Log\\NullLogger'),
                                 )
                             ),
                         ],

--- a/src/Cloud/Auth.php
+++ b/src/Cloud/Auth.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud;
 
-use DateTimeInterface;
 use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud\DTO\OrganizationId;
 use Kiboko\Component\Satellite\Cloud\DTO\WorkspaceId;
@@ -167,7 +166,7 @@ final class Auth
             throw new AccessDeniedException('There is no available token to authenticate to the service.');
         }
 
-        $date = \DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->configuration[$url]['date']);
+        $date = \DateTimeImmutable::createFromFormat(\DateTimeInterface::RFC3339_EXTENDED, $this->configuration[$url]['date']);
         if ($date <= new \DateTimeImmutable('-1 hour')) {
             throw new AccessDeniedException('The stored token has expired, you need a fresh token to authenticate to the service.');
         }

--- a/src/Cloud/Auth.php
+++ b/src/Cloud/Auth.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud;
 
+use DateTimeInterface;
 use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud\DTO\OrganizationId;
 use Kiboko\Component\Satellite\Cloud\DTO\WorkspaceId;
@@ -166,10 +167,10 @@ final class Auth
             throw new AccessDeniedException('There is no available token to authenticate to the service.');
         }
 
-        //        $date = \DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC3339_EXTENDED, $this->configuration[$url]['date']);
-        //        if ($date <= new \DateTimeImmutable('-1 hour')) {
-        //            throw new AccessDeniedException('The stored token has expired, you need a fresh token to authenticate to the service.');
-        //        }
+        $date = \DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->configuration[$url]['date']);
+        if ($date <= new \DateTimeImmutable('-1 hour')) {
+            throw new AccessDeniedException('The stored token has expired, you need a fresh token to authenticate to the service.');
+        }
 
         return $this->configuration[$url]['token'];
     }

--- a/src/Cloud/Command/Pipeline/AddBeforePipelineStepCommand.php
+++ b/src/Cloud/Command/Pipeline/AddBeforePipelineStepCommand.php
@@ -8,7 +8,6 @@ use Kiboko\Component\Satellite\Cloud\Command\Command;
 use Kiboko\Component\Satellite\Cloud\DTO\PipelineId;
 use Kiboko\Component\Satellite\Cloud\DTO\Step;
 use Kiboko\Component\Satellite\Cloud\DTO\StepCode;
-
 final class AddBeforePipelineStepCommand implements Command
 {
     public function __construct(

--- a/src/Cloud/Command/Pipeline/AddBeforePipelineStepCommand.php
+++ b/src/Cloud/Command/Pipeline/AddBeforePipelineStepCommand.php
@@ -8,6 +8,7 @@ use Kiboko\Component\Satellite\Cloud\Command\Command;
 use Kiboko\Component\Satellite\Cloud\DTO\PipelineId;
 use Kiboko\Component\Satellite\Cloud\DTO\Step;
 use Kiboko\Component\Satellite\Cloud\DTO\StepCode;
+
 final class AddBeforePipelineStepCommand implements Command
 {
     public function __construct(

--- a/src/Cloud/Command/Pipeline/DeclarePipelineCommand.php
+++ b/src/Cloud/Command/Pipeline/DeclarePipelineCommand.php
@@ -13,10 +13,7 @@ final class DeclarePipelineCommand implements Command
         public string $code,
         public string $label,
         public DTO\StepList $steps,
-        public DTO\Autoload $autoload,
-        public DTO\PackageList $packages,
-        public DTO\RepositoryList $repositories,
-        public DTO\AuthList $auths,
+        public DTO\Composer $composer,
         public DTO\OrganizationId $organizationId,
         public DTO\WorkspaceId $project,
     ) {

--- a/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+final class AddAfterWorkflowJobCommand implements Command
+{
+    public function __construct(
+        DTO\WorkflowId $workflowId,
+        DTO\JobCode $code,
+        DTO\Workflow\JobInterface $job,
+    ) {}
+}

--- a/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
@@ -10,8 +10,8 @@ use Kiboko\Component\Satellite\Cloud\DTO;
 final class AddAfterWorkflowJobCommand implements Command
 {
     public function __construct(
-        DTO\WorkflowId $workflowId,
-        DTO\JobCode $code,
-        DTO\Workflow\JobInterface $job,
+        public DTO\WorkflowId $workflowId,
+        public DTO\JobCode $code,
+        public DTO\Workflow\JobInterface $job,
     ) {}
 }

--- a/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/AddAfterWorkflowJobCommand.php
@@ -13,5 +13,6 @@ final class AddAfterWorkflowJobCommand implements Command
         public DTO\WorkflowId $workflowId,
         public DTO\JobCode $code,
         public DTO\Workflow\JobInterface $job,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+final class DeclareWorkflowCommand implements Command
+{
+    public function __construct(
+        public string $code,
+        public string $label,
+        public DTO\JobList $jobs,
+        public DTO\Autoload $autoload,
+        public DTO\PackageList $packages,
+        public DTO\RepositoryList $repositories,
+        public DTO\AuthList $auths,
+        public DTO\OrganizationId $organizationId,
+        public DTO\WorkspaceId $project,
+    ) {}
+}

--- a/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
@@ -13,10 +13,7 @@ final class DeclareWorkflowCommand implements Command
         public string $code,
         public string $label,
         public DTO\JobList $jobs,
-        public DTO\Autoload $autoload,
-        public DTO\PackageList $packages,
-        public DTO\RepositoryList $repositories,
-        public DTO\AuthList $auths,
+        public DTO\Composer $composer,
         public DTO\OrganizationId $organizationId,
         public DTO\WorkspaceId $project,
     ) {}

--- a/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/DeclareWorkflowCommand.php
@@ -16,5 +16,6 @@ final class DeclareWorkflowCommand implements Command
         public DTO\Composer $composer,
         public DTO\OrganizationId $organizationId,
         public DTO\WorkspaceId $project,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
@@ -10,7 +10,7 @@ use Kiboko\Component\Satellite\Cloud\DTO;
 final class PrependWorkflowJobCommand implements Command
 {
     public function __construct(
-        DTO\WorkflowId $workflowId,
-        DTO\Workflow\JobInterface $job,
+        public DTO\WorkflowId $workflowId,
+        public DTO\Workflow\JobInterface $job,
     ) {}
 }

--- a/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+final class PrependWorkflowJobCommand implements Command
+{
+    public function __construct(
+        DTO\WorkflowId $workflowId,
+        DTO\Workflow\JobInterface $job,
+    ) {}
+}

--- a/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/PrependWorkflowJobCommand.php
@@ -12,5 +12,6 @@ final class PrependWorkflowJobCommand implements Command
     public function __construct(
         public DTO\WorkflowId $workflowId,
         public DTO\Workflow\JobInterface $job,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO\WorkflowId;
+
+final class RemoveWorkflowCommand implements Command
+{
+    public function __construct(
+        public WorkflowId $workflow,
+    ) {}
+}

--- a/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
@@ -11,5 +11,6 @@ final class RemoveWorkflowCommand implements Command
 {
     public function __construct(
         public WorkflowId $id,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowCommand.php
@@ -10,6 +10,6 @@ use Kiboko\Component\Satellite\Cloud\DTO\WorkflowId;
 final class RemoveWorkflowCommand implements Command
 {
     public function __construct(
-        public WorkflowId $workflow,
+        public WorkflowId $id,
     ) {}
 }

--- a/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
@@ -12,5 +12,6 @@ final class RemoveWorkflowJobCommand implements Command
     public function __construct(
         public DTO\WorkflowId $workflowId,
         public DTO\StepCode $stepCode,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+final class RemoveWorkflowJobCommand implements Command
+{
+    public function __construct(
+        DTO\WorkflowId $workflowId,
+        DTO\StepCode $stepCode,
+    ) {}
+}

--- a/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/RemoveWorkflowJobCommand.php
@@ -10,7 +10,7 @@ use Kiboko\Component\Satellite\Cloud\DTO;
 final class RemoveWorkflowJobCommand implements Command
 {
     public function __construct(
-        DTO\WorkflowId $workflowId,
-        DTO\StepCode $stepCode,
+        public DTO\WorkflowId $workflowId,
+        public DTO\StepCode $stepCode,
     ) {}
 }

--- a/src/Cloud/Command/Workflow/ReorderWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/ReorderWorkflowJobCommand.php
@@ -9,9 +9,13 @@ use Kiboko\Component\Satellite\Cloud\DTO;
 
 class ReorderWorkflowJobCommand implements Command
 {
+    /** @var list<DTO\JobCode> */
+    public array $codes;
+
     public function __construct(
-        DTO\WorkflowId $workflowId,
-        $param,
-        array $array_map
-    ) {}
+        public DTO\WorkflowId $workflowId,
+        DTO\JobCode ...$codes,
+    ) {
+        $this->codes = $codes;
+    }
 }

--- a/src/Cloud/Command/Workflow/ReorderWorkflowJobCommand.php
+++ b/src/Cloud/Command/Workflow/ReorderWorkflowJobCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Command\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\Command\Command;
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+class ReorderWorkflowJobCommand implements Command
+{
+    public function __construct(
+        DTO\WorkflowId $workflowId,
+        $param,
+        array $array_map
+    ) {}
+}

--- a/src/Cloud/CommandBus.php
+++ b/src/Cloud/CommandBus.php
@@ -31,6 +31,7 @@ final class CommandBus
             Satellite\Cloud\Command\Pipeline\ReplacePipelineStepCommand::class => new Satellite\Cloud\Handler\Pipeline\ReplacePipelineStepCommandHandler($client),
             Satellite\Cloud\Command\Pipeline\RemovePipelineStepCommand::class => new Satellite\Cloud\Handler\Pipeline\RemovePipelineStepCommandHandler($client),
             Satellite\Cloud\Command\Workflow\DeclareWorkflowCommand::class => new Satellite\Cloud\Handler\Workflow\DeclareWorkflowCommandHandler($client),
+            Satellite\Cloud\Command\Workflow\RemoveWorkflowCommand::class => new Satellite\Cloud\Handler\Workflow\RemoveWorkflowCommandHandler($client),
         ]);
     }
 

--- a/src/Cloud/CommandBus.php
+++ b/src/Cloud/CommandBus.php
@@ -30,6 +30,7 @@ final class CommandBus
             Satellite\Cloud\Command\Pipeline\AddBeforePipelineStepCommand::class => new Satellite\Cloud\Handler\Pipeline\AddBeforePipelineStepCommandHandler($client),
             Satellite\Cloud\Command\Pipeline\ReplacePipelineStepCommand::class => new Satellite\Cloud\Handler\Pipeline\ReplacePipelineStepCommandHandler($client),
             Satellite\Cloud\Command\Pipeline\RemovePipelineStepCommand::class => new Satellite\Cloud\Handler\Pipeline\RemovePipelineStepCommandHandler($client),
+            Satellite\Cloud\Command\Workflow\DeclareWorkflowCommand::class => new Satellite\Cloud\Handler\Workflow\DeclareWorkflowCommandHandler($client),
         ]);
     }
 

--- a/src/Cloud/Console/Command/ArgumentType.php
+++ b/src/Cloud/Console/Command/ArgumentType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Console\Command;
+
+enum ArgumentType: string
+{
+    case PIPELINE = 'pipeline';
+    case WORKFLOW = 'workflow';
+}

--- a/src/Cloud/Console/Command/CreateCommand.php
+++ b/src/Cloud/Console/Command/CreateCommand.php
@@ -89,7 +89,7 @@ final class CreateCommand extends Console\Command\Command
         }
 
         if (!\array_key_exists('version', $configuration)) {
-            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration to version 0.3.');
+            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration at least to version 0.3.');
 
             return self::INVALID;
         }

--- a/src/Cloud/Console/Command/CreateCommand.php
+++ b/src/Cloud/Console/Command/CreateCommand.php
@@ -131,8 +131,8 @@ final class CreateCommand extends Console\Command\Command
         foreach ($configuration['satellites'] as $code => $satellite) {
             $satellite['code'] = $code;
             $instance = match (true) {
-                array_key_exists('pipeline', $satellite) => new Satellite\Cloud\Pipeline($context),
-                array_key_exists('workflow', $satellite) => new Satellite\Cloud\Workflow($context),
+                \array_key_exists('pipeline', $satellite) => new Satellite\Cloud\Pipeline($context),
+                \array_key_exists('workflow', $satellite) => new Satellite\Cloud\Workflow($context),
                 default => throw new \RuntimeException('Invalid runtime satellite configuration.'),
             };
 

--- a/src/Cloud/Console/Command/CreateCommand.php
+++ b/src/Cloud/Console/Command/CreateCommand.php
@@ -23,7 +23,7 @@ final class CreateCommand extends Console\Command\Command
         $this->addOption('beta', mode: Console\Input\InputOption::VALUE_NONE, description: 'Shortcut to set the cloud instance to https://beta.gyroscops.com');
         $this->addOption('ssl', mode: Console\Input\InputOption::VALUE_NEGATABLE, description: 'Enable or disable SSL');
         $this->addArgument('config', Console\Input\InputArgument::REQUIRED);
-        $this->addArgument('type', Console\Input\InputArgument::REQUIRED, 'Type de configuration (pipeline ou workflow)');
+        $this->addArgument('type', Console\Input\InputArgument::REQUIRED, 'Type of runtime (pipeline ou workflow)');
     }
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
@@ -64,8 +64,9 @@ final class CreateCommand extends Console\Command\Command
         }
 
         $type = $input->getArgument('type');
-        if ($type !== 'pipeline' && $type !== 'workflow') {
-            $output->writeln('Le type doit être soit "pipeline" soit "workflow".');
+        if ('pipeline' !== $type && 'workflow' !== $type) {
+            $output->writeln('The type must be either "pipeline" or "workflow".');
+
             return Console\Command\Command::FAILURE;
         }
 
@@ -129,31 +130,21 @@ final class CreateCommand extends Console\Command\Command
 
         $context = new Satellite\Cloud\Context($client, $auth, $url);
 
-        if ($type === 'pipeline') {
-            $pipeline = new Satellite\Cloud\Pipeline($context);
-            if (!\array_key_exists('version', $configuration)) {
-                foreach ($pipeline->create(Satellite\Cloud\Pipeline::fromLegacyConfiguration($configuration['satellite'])) as $command) {
-                    $bus->push($command);
-                }
-            } else {
-                foreach ($configuration['satellites'] as $satellite) {
-                    foreach ($pipeline->create(Satellite\Cloud\Pipeline::fromLegacyConfiguration($satellite)) as $command) {
-                        $bus->push($command);
-                    }
-                }
-            }
-        } elseif ($type === 'workflow') {
-            $workflow = new Satellite\Cloud\Workflow($context);
-            if (!\array_key_exists('version', $configuration)) {
-                foreach ($workflow->create(Satellite\Cloud\Workflow::fromLegacyConfiguration($configuration['satellite'])) as $command) {
-                    $bus->push($command);
-                }
-            } else {
-                foreach ($configuration['satellites'] as $satellite) {
-                    foreach ($workflow->create(Satellite\Cloud\Workflow::fromLegacyConfiguration($satellite)) as $command) {
-                        $bus->push($command);
-                    }
-                }
+        match ($type) {
+            ArgumentType::PIPELINE->value => $satellites = !\array_key_exists('version', $configuration) ? $configuration['satellite']['pipeline'] : $configuration['satellites'],
+            ArgumentType::WORKFLOW->value => $satellites = !\array_key_exists('version', $configuration) ? $configuration['satellite']['workflow'] : $configuration['satellites'],
+            default => throw new \InvalidArgumentException('Invalid type provided.'),
+        };
+
+        $instance = match ($type) {
+            ArgumentType::PIPELINE->value => new Satellite\Cloud\Pipeline($context),
+            ArgumentType::WORKFLOW->value => new Satellite\Cloud\Workflow($context),
+            default => throw new \InvalidArgumentException('Invalid type provided.'),
+        };
+
+        foreach ($satellites as $satellite) {
+            foreach ($instance->create($instance::fromLegacyConfiguration($satellite)) as $command) {
+                $bus->push($command);
             }
         }
 

--- a/src/Cloud/Console/Command/RemoveCommand.php
+++ b/src/Cloud/Console/Command/RemoveCommand.php
@@ -124,8 +124,8 @@ final class RemoveCommand extends Console\Command\Command
 
         $context = new Satellite\Cloud\Context($client, $auth, $url);
         $instance = match (true) {
-            array_key_exists('pipeline', $configuration) => new Satellite\Cloud\Pipeline($context),
-            array_key_exists('workflow', $configuration) => new Satellite\Cloud\Workflow($context),
+            \array_key_exists('pipeline', $configuration) => new Satellite\Cloud\Pipeline($context),
+            \array_key_exists('workflow', $configuration) => new Satellite\Cloud\Workflow($context),
             default => throw new \RuntimeException('Invalid runtime satellite configuration.'),
         };
 

--- a/src/Cloud/Console/Command/RemoveCommand.php
+++ b/src/Cloud/Console/Command/RemoveCommand.php
@@ -28,6 +28,7 @@ final class RemoveCommand extends Console\Command\Command
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
     {
+        $configuration = [];
         $style = new Console\Style\SymfonyStyle(
             $input,
             $output,

--- a/src/Cloud/Console/Command/RemoveCommand.php
+++ b/src/Cloud/Console/Command/RemoveCommand.php
@@ -22,7 +22,7 @@ final class RemoveCommand extends Console\Command\Command
         $this->addOption('url', 'u', mode: Console\Input\InputArgument::OPTIONAL, description: 'Base URL of the cloud instance', default: 'https://app.gyroscops.com');
         $this->addOption('beta', mode: Console\Input\InputOption::VALUE_NONE, description: 'Shortcut to set the cloud instance to https://beta.gyroscops.com');
         $this->addOption('ssl', mode: Console\Input\InputOption::VALUE_NEGATABLE, description: 'Enable or disable SSL');
-        $this->addOption('output', mode: Console\Input\InputOption::VALUE_OPTIONAL, description: 'Specify the path of the working directory');
+        $this->addOption('output', mode: Console\Input\InputOption::VALUE_OPTIONAL, description: 'Specify the path of the resulting tarball when building for Docker');
         $this->addArgument('config', mode: Console\Input\InputArgument::REQUIRED);
     }
 
@@ -87,7 +87,7 @@ final class RemoveCommand extends Console\Command\Command
         }
 
         if (!\array_key_exists('version', $configuration)) {
-            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration to version 0.3.');
+            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration at least to version 0.3.');
 
             return self::INVALID;
         }

--- a/src/Cloud/Console/Command/RemoveCommand.php
+++ b/src/Cloud/Console/Command/RemoveCommand.php
@@ -22,6 +22,7 @@ final class RemoveCommand extends Console\Command\Command
         $this->addOption('url', 'u', mode: Console\Input\InputArgument::OPTIONAL, description: 'Base URL of the cloud instance', default: 'https://app.gyroscops.com');
         $this->addOption('beta', mode: Console\Input\InputOption::VALUE_NONE, description: 'Shortcut to set the cloud instance to https://beta.gyroscops.com');
         $this->addOption('ssl', mode: Console\Input\InputOption::VALUE_NEGATABLE, description: 'Enable or disable SSL');
+        $this->addOption('output', mode: Console\Input\InputOption::VALUE_OPTIONAL, description: 'Specify the path of the working directory');
         $this->addArgument('config', mode: Console\Input\InputArgument::REQUIRED);
     }
 
@@ -70,7 +71,7 @@ final class RemoveCommand extends Console\Command\Command
         }
 
         $context = new Satellite\Console\RuntimeContext(
-            'php://fd/3',
+            $input->getOption('output') ?? 'php://fd/3',
             new Satellite\ExpressionLanguage\ExpressionLanguage(),
         );
 

--- a/src/Cloud/Console/Command/UpdateCommand.php
+++ b/src/Cloud/Console/Command/UpdateCommand.php
@@ -127,8 +127,8 @@ final class UpdateCommand extends Console\Command\Command
 
         $context = new Satellite\Cloud\Context($client, $auth, $url);
         $instance = match (true) {
-            array_key_exists('pipeline', $configuration) => new Satellite\Cloud\Pipeline($context),
-            array_key_exists('workflow', $configuration) => new Satellite\Cloud\Workflow($context),
+            \array_key_exists('pipeline', $configuration) => new Satellite\Cloud\Pipeline($context),
+            \array_key_exists('workflow', $configuration) => new Satellite\Cloud\Workflow($context),
             default => throw new \RuntimeException('Invalid runtime satellite configuration.'),
         };
 

--- a/src/Cloud/Console/Command/UpdateCommand.php
+++ b/src/Cloud/Console/Command/UpdateCommand.php
@@ -89,7 +89,7 @@ final class UpdateCommand extends Console\Command\Command
         }
 
         if (!\array_key_exists('version', $configuration)) {
-            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration to version 0.3.');
+            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration at least to version 0.3.');
 
             return self::INVALID;
         }

--- a/src/Cloud/Console/Command/UpdateCommand.php
+++ b/src/Cloud/Console/Command/UpdateCommand.php
@@ -96,6 +96,12 @@ final class UpdateCommand extends Console\Command\Command
             return self::FAILURE;
         }
 
+        if (!\array_key_exists('version', $configuration)) {
+            $style->warning('The current version of your configuration does not allow you to use Cloud commands. Please update your configuration to version 0.3.');
+
+            return self::INVALID;
+        }
+
         $auth = new Satellite\Cloud\Auth();
         try {
             $token = $auth->token($url);
@@ -128,19 +134,13 @@ final class UpdateCommand extends Console\Command\Command
         }
 
         $context = new Satellite\Cloud\Context($client, $auth, $url);
-        match ($type) {
-            ArgumentType::PIPELINE->value => $model = Satellite\Cloud\Pipeline::fromApiWithCode($client, array_key_first($configuration['satellites']), $configuration['satellite']['pipeline']),
-            ArgumentType::WORKFLOW->value => $model = Satellite\Cloud\Workflow::fromApiWithCode($client, array_key_first($configuration['satellites'])),
-            default => throw new \InvalidArgumentException('Invalid type provided.'),
-        };
-
         $instance = match ($type) {
             ArgumentType::PIPELINE->value => new Satellite\Cloud\Pipeline($context),
             ArgumentType::WORKFLOW->value => new Satellite\Cloud\Workflow($context),
             default => throw new \InvalidArgumentException('Invalid type provided.'),
         };
 
-        foreach ($instance->update($model, $instance::fromLegacyConfiguration($configuration['satellite'])) as $command) {
+        foreach ($instance->update($instance::fromApiWithCode($client, array_key_first($configuration['satellites'])), $instance::fromLegacyConfiguration($configuration['satellite'])) as $command) {
             $bus->push($command);
         }
 

--- a/src/Cloud/Console/Command/UpdateCommand.php
+++ b/src/Cloud/Console/Command/UpdateCommand.php
@@ -23,7 +23,6 @@ final class UpdateCommand extends Console\Command\Command
         $this->addOption('beta', mode: Console\Input\InputOption::VALUE_NONE, description: 'Shortcut to set the cloud instance to https://beta.gyroscops.com');
         $this->addOption('ssl', mode: Console\Input\InputOption::VALUE_NEGATABLE, description: 'Enable or disable SSL');
         $this->addArgument('config', Console\Input\InputArgument::REQUIRED);
-        $this->addArgument('type', Console\Input\InputArgument::REQUIRED, 'Type of runtime (pipeline ou workflow)');
     }
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
@@ -61,13 +60,6 @@ final class UpdateCommand extends Console\Command\Command
             if (!isset($configuration)) {
                 throw new \RuntimeException('Could not find configuration file.');
             }
-        }
-
-        $type = $input->getArgument('type');
-        if ('pipeline' !== $type && 'workflow' !== $type) {
-            $output->writeln('The type must be either "pipeline" or "workflow.');
-
-            return Console\Command\Command::FAILURE;
         }
 
         for ($directory = getcwd(); '/' !== $directory; $directory = \dirname($directory)) {
@@ -134,10 +126,10 @@ final class UpdateCommand extends Console\Command\Command
         }
 
         $context = new Satellite\Cloud\Context($client, $auth, $url);
-        $instance = match ($type) {
-            ArgumentType::PIPELINE->value => new Satellite\Cloud\Pipeline($context),
-            ArgumentType::WORKFLOW->value => new Satellite\Cloud\Workflow($context),
-            default => throw new \InvalidArgumentException('Invalid type provided.'),
+        $instance = match (true) {
+            array_key_exists('pipeline', $configuration) => new Satellite\Cloud\Pipeline($context),
+            array_key_exists('workflow', $configuration) => new Satellite\Cloud\Workflow($context),
+            default => throw new \RuntimeException('Invalid runtime satellite configuration.'),
         };
 
         foreach ($instance->update($instance::fromApiWithCode($client, array_key_first($configuration['satellites'])), $instance::fromLegacyConfiguration($configuration['satellite'])) as $command) {

--- a/src/Cloud/DTO/Composer.php
+++ b/src/Cloud/DTO/Composer.php
@@ -11,7 +11,8 @@ final readonly class Composer
         private PackageList $packages,
         private RepositoryList $repositories,
         private AuthList $auths,
-    ) {}
+    ) {
+    }
 
     public function autoload(): Autoload
     {

--- a/src/Cloud/DTO/Composer.php
+++ b/src/Cloud/DTO/Composer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class Composer
+{
+    public function __construct(
+        private Autoload $autoload,
+        private PackageList $packages,
+        private RepositoryList $repositories,
+        private AuthList $auths,
+    ) {}
+
+    public function autoload(): Autoload
+    {
+        return $this->autoload;
+    }
+
+    public function packages(): PackageList
+    {
+        return $this->packages;
+    }
+
+    public function repositories(): RepositoryList
+    {
+        return $this->repositories;
+    }
+
+    public function auths(): AuthList
+    {
+        return $this->auths;
+    }
+}

--- a/src/Cloud/DTO/JobCode.php
+++ b/src/Cloud/DTO/JobCode.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class JobCode implements \Stringable
+{
+    public function __construct(
+        private string $reference,
+    ) {}
+
+    public function asString(): string
+    {
+        return $this->reference;
+    }
+
+    public function __toString(): string
+    {
+        return $this->reference;
+    }
+}

--- a/src/Cloud/DTO/JobCode.php
+++ b/src/Cloud/DTO/JobCode.php
@@ -8,7 +8,8 @@ final readonly class JobCode implements \Stringable
 {
     public function __construct(
         private string $reference,
-    ) {}
+    ) {
+    }
 
     public function asString(): string
     {

--- a/src/Cloud/DTO/JobList.php
+++ b/src/Cloud/DTO/JobList.php
@@ -20,7 +20,7 @@ readonly class JobList implements \Countable, \IteratorAggregate
     {
         $jobs = $this->jobs;
 
-        /** @phpstan-ignore-next-line  */
+        /* @phpstan-ignore-next-line */
         usort($jobs, fn (DTO\Workflow\JobInterface $left, DTO\Workflow\JobInterface $right) => $left->order <=> $right->order);
 
         return new \ArrayIterator($jobs);
@@ -30,10 +30,10 @@ readonly class JobList implements \Countable, \IteratorAggregate
     {
         $jobs = $this->jobs;
 
-        /** @phpstan-ignore-next-line  */
+        /* @phpstan-ignore-next-line */
         usort($jobs, fn (DTO\Workflow\JobInterface $left, DTO\Workflow\JobInterface $right) => $left->order <=> $right->order);
 
-        /** @phpstan-ignore-next-line  */
+        /* @phpstan-ignore-next-line */
         return array_map(fn (DTO\Workflow\JobInterface $job) => $job->code->asString(), $jobs);
     }
 

--- a/src/Cloud/DTO/JobList.php
+++ b/src/Cloud/DTO/JobList.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+use Kiboko\Component\Satellite\Cloud\DTO\Workflow\JobInterface;
+
+readonly class JobList implements \Countable, \IteratorAggregate
+{
+    /** @var list<JobInterface> */
+    private array $jobs;
+
+    public function __construct(
+        JobInterface ...$job,
+    ) {
+        $this->jobs = $job;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        $jobs = $this->jobs;
+        usort($jobs, fn (JobInterface $left, JobInterface $right) => $left->order <=> $right->order);
+
+        return new \ArrayIterator($jobs);
+    }
+
+    public function codes(): array
+    {
+        $jobs = $this->jobs;
+        usort($jobs, fn (JobInterface $left, JobInterface $right) => $left->order <=> $right->order);
+
+        return array_map(fn (JobInterface $job) => $job->code->asString(), $jobs);
+    }
+
+    public function get(string $code): JobInterface
+    {
+        foreach ($this->jobs as $job) {
+            if ($job->code->asString() === $code) {
+                return $job;
+            }
+        }
+
+        throw new \OutOfBoundsException('There was no job found matching the provided code');
+    }
+
+    public function count(): int
+    {
+        return \count($this->jobs);
+    }
+
+    public function map(callable $callback): array
+    {
+        return array_map($callback, $this->jobs);
+    }
+}

--- a/src/Cloud/DTO/JobList.php
+++ b/src/Cloud/DTO/JobList.php
@@ -4,15 +4,14 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO;
 
-use Kiboko\Component\Satellite\Cloud\DTO\Workflow\JobInterface;
+use Kiboko\Component\Satellite\Cloud\DTO;
 
 readonly class JobList implements \Countable, \IteratorAggregate
 {
-    /** @var list<JobInterface> */
     private array $jobs;
 
     public function __construct(
-        JobInterface ...$job,
+        DTO\Workflow\JobInterface ...$job,
     ) {
         $this->jobs = $job;
     }
@@ -20,7 +19,9 @@ readonly class JobList implements \Countable, \IteratorAggregate
     public function getIterator(): \Traversable
     {
         $jobs = $this->jobs;
-        usort($jobs, fn (JobInterface $left, JobInterface $right) => $left->order <=> $right->order);
+
+        /** @phpstan-ignore-next-line  */
+        usort($jobs, fn (DTO\Workflow\JobInterface $left, DTO\Workflow\JobInterface $right) => $left->order <=> $right->order);
 
         return new \ArrayIterator($jobs);
     }
@@ -28,12 +29,15 @@ readonly class JobList implements \Countable, \IteratorAggregate
     public function codes(): array
     {
         $jobs = $this->jobs;
-        usort($jobs, fn (JobInterface $left, JobInterface $right) => $left->order <=> $right->order);
 
-        return array_map(fn (JobInterface $job) => $job->code->asString(), $jobs);
+        /** @phpstan-ignore-next-line  */
+        usort($jobs, fn (DTO\Workflow\JobInterface $left, DTO\Workflow\JobInterface $right) => $left->order <=> $right->order);
+
+        /** @phpstan-ignore-next-line  */
+        return array_map(fn (DTO\Workflow\JobInterface $job) => $job->code->asString(), $jobs);
     }
 
-    public function get(string $code): JobInterface
+    public function get(string $code): DTO\Workflow\JobInterface
     {
         foreach ($this->jobs as $job) {
             if ($job->code->asString() === $code) {

--- a/src/Cloud/DTO/Pipeline.php
+++ b/src/Cloud/DTO/Pipeline.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO;
 
-final readonly class Pipeline implements PipelineInterface
+final readonly class Pipeline implements SatelliteInterface, PipelineInterface
 {
     public function __construct(
         private string $label,
         private string $code,
         private StepList $steps,
-        private Autoload $autoload = new Autoload(),
-        private PackageList $packages = new PackageList(),
-        private RepositoryList $repositories = new RepositoryList(),
-        private AuthList $auths = new AuthList(),
+        private Composer $composer,
     ) {
     }
 
@@ -32,23 +29,8 @@ final readonly class Pipeline implements PipelineInterface
         return $this->steps;
     }
 
-    public function autoload(): Autoload
+    public function composer(): Composer
     {
-        return $this->autoload;
-    }
-
-    public function packages(): PackageList
-    {
-        return $this->packages;
-    }
-
-    public function repositories(): RepositoryList
-    {
-        return $this->repositories;
-    }
-
-    public function auths(): AuthList
-    {
-        return $this->auths;
+        return $this->composer;
     }
 }

--- a/src/Cloud/DTO/PipelineInterface.php
+++ b/src/Cloud/DTO/PipelineInterface.php
@@ -11,12 +11,4 @@ interface PipelineInterface
     public function label(): string;
 
     public function steps(): StepList;
-
-    public function autoload(): Autoload;
-
-    public function packages(): PackageList;
-
-    public function repositories(): RepositoryList;
-
-    public function auths(): AuthList;
 }

--- a/src/Cloud/DTO/ReferencedPipeline.php
+++ b/src/Cloud/DTO/ReferencedPipeline.php
@@ -34,21 +34,21 @@ final readonly class ReferencedPipeline implements PipelineInterface
 
     public function autoload(): Autoload
     {
-        return $this->decorated->autoload();
+        return $this->decorated->composer()->autoload();
     }
 
     public function packages(): PackageList
     {
-        return $this->decorated->packages();
+        return $this->decorated->composer()->packages();
     }
 
     public function repositories(): RepositoryList
     {
-        return $this->decorated->repositories();
+        return $this->decorated->composer()->repositories();
     }
 
     public function auths(): AuthList
     {
-        return $this->decorated->auths();
+        return $this->decorated->composer()->auths();
     }
 }

--- a/src/Cloud/DTO/ReferencedWorkflow.php
+++ b/src/Cloud/DTO/ReferencedWorkflow.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final class ReferencedWorkflow implements WorkflowInterface
+{
+    public function __construct(
+        private WorkflowId $id,
+        private Workflow $decorated,
+    ) {}
+
+    public function id(): WorkflowId
+    {
+        return $this->id;
+    }
+
+    public function code(): string
+    {
+        return $this->decorated->code();
+    }
+
+    public function label(): string
+    {
+        return $this->decorated->label();
+    }
+
+    public function jobs(): JobList
+    {
+        return $this->decorated->jobs();
+    }
+
+    public function autoload(): Autoload
+    {
+        return $this->decorated->autoload();
+    }
+
+    public function packages(): PackageList
+    {
+        return $this->decorated->packages();
+    }
+
+    public function repositories(): RepositoryList
+    {
+        return $this->decorated->repositories();
+    }
+
+    public function auths(): AuthList
+    {
+        return $this->decorated->auths();
+    }
+}

--- a/src/Cloud/DTO/ReferencedWorkflow.php
+++ b/src/Cloud/DTO/ReferencedWorkflow.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO;
 
-final class ReferencedWorkflow implements WorkflowInterface
+final readonly class ReferencedWorkflow implements WorkflowInterface
 {
     public function __construct(
         private WorkflowId $id,

--- a/src/Cloud/DTO/ReferencedWorkflow.php
+++ b/src/Cloud/DTO/ReferencedWorkflow.php
@@ -33,21 +33,21 @@ final readonly class ReferencedWorkflow implements WorkflowInterface
 
     public function autoload(): Autoload
     {
-        return $this->decorated->autoload();
+        return $this->decorated->composer()->autoload();
     }
 
     public function packages(): PackageList
     {
-        return $this->decorated->packages();
+        return $this->decorated->composer()->packages();
     }
 
     public function repositories(): RepositoryList
     {
-        return $this->decorated->repositories();
+        return $this->decorated->composer()->repositories();
     }
 
     public function auths(): AuthList
     {
-        return $this->decorated->auths();
+        return $this->decorated->composer()->auths();
     }
 }

--- a/src/Cloud/DTO/ReferencedWorkflow.php
+++ b/src/Cloud/DTO/ReferencedWorkflow.php
@@ -9,7 +9,8 @@ final readonly class ReferencedWorkflow implements WorkflowInterface
     public function __construct(
         private WorkflowId $id,
         private Workflow $decorated,
-    ) {}
+    ) {
+    }
 
     public function id(): WorkflowId
     {

--- a/src/Cloud/DTO/SatelliteId.php
+++ b/src/Cloud/DTO/SatelliteId.php
@@ -8,7 +8,8 @@ final readonly class SatelliteId implements \Stringable
 {
     public function __construct(
         private string $reference,
-    ) {}
+    ) {
+    }
 
     public function asString(): string
     {

--- a/src/Cloud/DTO/SatelliteId.php
+++ b/src/Cloud/DTO/SatelliteId.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class SatelliteId implements \Stringable
+{
+    public function __construct(
+        private string $reference,
+    ) {}
+
+    public function asString(): string
+    {
+        return $this->reference;
+    }
+
+    public function __toString(): string
+    {
+        return $this->reference;
+    }
+}

--- a/src/Cloud/DTO/SatelliteInterface.php
+++ b/src/Cloud/DTO/SatelliteInterface.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO;
 
-interface WorkflowInterface
+interface SatelliteInterface
 {
     public function code(): string;
 
     public function label(): string;
 
-    public function jobs(): JobList;
+    public function composer(): Composer;
 }

--- a/src/Cloud/DTO/Workflow.php
+++ b/src/Cloud/DTO/Workflow.php
@@ -11,7 +11,8 @@ final readonly class Workflow implements SatelliteInterface, WorkflowInterface
         private string $code,
         private JobList $jobs,
         private Composer $composer,
-    ) {}
+    ) {
+    }
 
     public function code(): string
     {

--- a/src/Cloud/DTO/Workflow.php
+++ b/src/Cloud/DTO/Workflow.php
@@ -4,16 +4,13 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO;
 
-final readonly class Workflow implements WorkflowInterface
+final readonly class Workflow implements SatelliteInterface, WorkflowInterface
 {
     public function __construct(
         private string $label,
         private string $code,
         private JobList $jobs,
-        private Autoload $autoload,
-        private PackageList $packages,
-        private RepositoryList $repositories,
-        private AuthList $auths,
+        private Composer $composer,
     ) {}
 
     public function code(): string
@@ -26,28 +23,13 @@ final readonly class Workflow implements WorkflowInterface
         return $this->label;
     }
 
+    public function composer(): Composer
+    {
+        return $this->composer;
+    }
+
     public function jobs(): JobList
     {
         return $this->jobs;
-    }
-
-    public function autoload(): Autoload
-    {
-        return $this->autoload;
-    }
-
-    public function packages(): PackageList
-    {
-        return $this->packages;
-    }
-
-    public function repositories(): RepositoryList
-    {
-        return $this->repositories;
-    }
-
-    public function auths(): AuthList
-    {
-        return $this->auths;
     }
 }

--- a/src/Cloud/DTO/Workflow.php
+++ b/src/Cloud/DTO/Workflow.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class Workflow implements WorkflowInterface
+{
+    public function __construct(
+        private string $label,
+        private string $code,
+        private JobList $jobs,
+        private Autoload $autoload,
+        private PackageList $packages,
+        private RepositoryList $repositories,
+        private AuthList $auths,
+    ) {}
+
+    public function code(): string
+    {
+        return $this->code;
+    }
+
+    public function label(): string
+    {
+        return $this->label;
+    }
+
+    public function jobs(): JobList
+    {
+        return $this->jobs;
+    }
+
+    public function autoload(): Autoload
+    {
+        return $this->autoload;
+    }
+
+    public function packages(): PackageList
+    {
+        return $this->packages;
+    }
+
+    public function repositories(): RepositoryList
+    {
+        return $this->repositories;
+    }
+
+    public function auths(): AuthList
+    {
+        return $this->auths;
+    }
+}

--- a/src/Cloud/DTO/Workflow/Action.php
+++ b/src/Cloud/DTO/Workflow/Action.php
@@ -13,6 +13,5 @@ final readonly class Action implements JobInterface
         public JobCode $code,
         public array $configuration,
         public int $order,
-    ) {
-    }
+    ) {}
 }

--- a/src/Cloud/DTO/Workflow/Action.php
+++ b/src/Cloud/DTO/Workflow/Action.php
@@ -13,5 +13,6 @@ final readonly class Action implements JobInterface
         public JobCode $code,
         public array $configuration,
         public int $order,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/DTO/Workflow/Action.php
+++ b/src/Cloud/DTO/Workflow/Action.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
+
+final readonly class Action implements JobInterface
+{
+    public function __construct(
+        public string $label,
+        public JobCode $code,
+        public array $configuration,
+        public int $order,
+    ) {
+    }
+}

--- a/src/Cloud/DTO/Workflow/JobInterface.php
+++ b/src/Cloud/DTO/Workflow/JobInterface.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO\Workflow;
 
-interface JobInterface {}
+interface JobInterface
+{
+}

--- a/src/Cloud/DTO/Workflow/JobInterface.php
+++ b/src/Cloud/DTO/Workflow/JobInterface.php
@@ -8,5 +8,4 @@ use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
 
 interface JobInterface
 {
-
 }

--- a/src/Cloud/DTO/Workflow/JobInterface.php
+++ b/src/Cloud/DTO/Workflow/JobInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
+
+interface JobInterface
+{
+
+}

--- a/src/Cloud/DTO/Workflow/JobInterface.php
+++ b/src/Cloud/DTO/Workflow/JobInterface.php
@@ -4,8 +4,4 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\DTO\Workflow;
 
-use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
-
-interface JobInterface
-{
-}
+interface JobInterface {}

--- a/src/Cloud/DTO/Workflow/Pipeline.php
+++ b/src/Cloud/DTO/Workflow/Pipeline.php
@@ -9,11 +9,10 @@ use Kiboko\Component\Satellite\Cloud\DTO\StepList;
 
 final readonly class Pipeline implements JobInterface
 {
-   public function __construct(
-       public string $label,
-       public JobCode $code,
-       public StepList $stepList,
-       public int $order,
-   ) {
-   }
+    public function __construct(
+        public string $label,
+        public JobCode $code,
+        public StepList $stepList,
+        public int $order,
+    ) {}
 }

--- a/src/Cloud/DTO/Workflow/Pipeline.php
+++ b/src/Cloud/DTO/Workflow/Pipeline.php
@@ -14,5 +14,6 @@ final readonly class Pipeline implements JobInterface
         public JobCode $code,
         public StepList $stepList,
         public int $order,
-    ) {}
+    ) {
+    }
 }

--- a/src/Cloud/DTO/Workflow/Pipeline.php
+++ b/src/Cloud/DTO/Workflow/Pipeline.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO\Workflow;
+
+use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
+use Kiboko\Component\Satellite\Cloud\DTO\StepList;
+
+final readonly class Pipeline implements JobInterface
+{
+   public function __construct(
+       public string $label,
+       public JobCode $code,
+       public StepList $stepList,
+       public int $order,
+   ) {
+   }
+}

--- a/src/Cloud/DTO/WorkflowId.php
+++ b/src/Cloud/DTO/WorkflowId.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class WorkflowId implements \Stringable
+{
+    public function __construct(
+        private string $reference,
+    ) {}
+
+    public function asString(): string
+    {
+        return $this->reference;
+    }
+
+    public function __toString(): string
+    {
+        return $this->reference;
+    }
+}

--- a/src/Cloud/DTO/WorkflowId.php
+++ b/src/Cloud/DTO/WorkflowId.php
@@ -8,7 +8,8 @@ final readonly class WorkflowId implements \Stringable
 {
     public function __construct(
         private string $reference,
-    ) {}
+    ) {
+    }
 
     public function asString(): string
     {

--- a/src/Cloud/DTO/WorkflowInterface.php
+++ b/src/Cloud/DTO/WorkflowInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\DTO;
+
+interface WorkflowInterface
+{
+    public function code(): string;
+
+    public function label(): string;
+
+    public function jobs(): JobList;
+
+    public function autoload(): Autoload;
+
+    public function packages(): PackageList;
+
+    public function repositories(): RepositoryList;
+
+    public function auths(): AuthList;
+}

--- a/src/Cloud/DeclareWorkflowFailedException.php
+++ b/src/Cloud/DeclareWorkflowFailedException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud;
+
+class DeclareWorkflowFailedException extends \RuntimeException {}

--- a/src/Cloud/DeclareWorkflowFailedException.php
+++ b/src/Cloud/DeclareWorkflowFailedException.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud;
 
-class DeclareWorkflowFailedException extends \RuntimeException {}
+class DeclareWorkflowFailedException extends \RuntimeException
+{
+}

--- a/src/Cloud/Diff/JobListDiff.php
+++ b/src/Cloud/Diff/JobListDiff.php
@@ -10,7 +10,8 @@ final readonly class JobListDiff
 {
     public function __construct(
         private DTO\WorkflowId $workflowId,
-    ) {}
+    ) {
+    }
 
     public function diff(DTO\JobList $left, DTO\JobList $right): DTO\CommandBatch
     {

--- a/src/Cloud/Diff/JobListDiff.php
+++ b/src/Cloud/Diff/JobListDiff.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Diff;
+
+use Kiboko\Component\Satellite\Cloud\DTO;
+
+final readonly class JobListDiff
+{
+    public function __construct(
+        private DTO\WorkflowId $workflowId,
+    ) {}
+
+    public function diff(DTO\JobList $left, DTO\JobList $right): DTO\CommandBatch
+    {
+        $commands = new DTO\CommandBatch();
+
+        $leftPositions = $left->codes();
+        $rightPositions = $right->codes();
+
+        foreach ($rightPositions as $desiredPosition => $code) {
+            // If the $right code does not exist in the $left list, then the step must be added
+            if (false !== array_search($code, $leftPositions, true)) {
+                continue;
+            }
+
+            if (0 === $desiredPosition) {
+                $commands->push(new \Kiboko\Component\Satellite\Cloud\Command\Workflow\PrependWorkflowJobCommand($this->workflowId, $right->get($code)));
+            } else {
+                $commands->push(new \Kiboko\Component\Satellite\Cloud\Command\Workflow\AddAfterWorkflowJobCommand($this->workflowId, new DTO\JobCode($rightPositions[$desiredPosition - 1]), $right->get($code)));
+            }
+        }
+
+        $offset = 0;
+        $needsReorder = false;
+        foreach ($leftPositions as $currentPosition => $code) {
+            // If the $left code does not exist in the $right list, then the step must be removed
+            if (($desiredPosition = array_search($code, $rightPositions, true)) === false) {
+                ++$offset;
+                $commands->push(new \Kiboko\Component\Satellite\Cloud\Command\Workflow\RemoveWorkflowJobCommand($this->workflowId, new DTO\StepCode($code)));
+                continue;
+            }
+
+            if (($desiredPosition + $offset) > $currentPosition) {
+                $needsReorder = true;
+            }
+        }
+
+        if (true === $needsReorder) {
+            $commands->push(new \Kiboko\Component\Satellite\Cloud\Command\Workflow\ReorderWorkflowJobCommand(
+                $this->workflowId,
+                ...array_map(fn (string $code) => new DTO\JobCode($code), $rightPositions)
+            ));
+        }
+
+        return $commands;
+    }
+}

--- a/src/Cloud/Event/Workflow/WorkflowDeclared.php
+++ b/src/Cloud/Event/Workflow/WorkflowDeclared.php
@@ -8,7 +8,8 @@ final readonly class WorkflowDeclared
 {
     public function __construct(
         private string $id,
-    ) {}
+    ) {
+    }
 
     public function getId(): string
     {

--- a/src/Cloud/Event/Workflow/WorkflowDeclared.php
+++ b/src/Cloud/Event/Workflow/WorkflowDeclared.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Event\Workflow;
+
+final readonly class WorkflowDeclared
+{
+    public function __construct(
+        private string $id,
+    ) {}
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Cloud/Event/Workflow/WorkflowRemoved.php
+++ b/src/Cloud/Event/Workflow/WorkflowRemoved.php
@@ -8,7 +8,8 @@ class WorkflowRemoved
 {
     public function __construct(
         private readonly string $id,
-    ) {}
+    ) {
+    }
 
     public function getId(): string
     {

--- a/src/Cloud/Event/Workflow/WorkflowRemoved.php
+++ b/src/Cloud/Event/Workflow/WorkflowRemoved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Kiboko\Component\Satellite\Cloud\Event\Workflow;
+
+class WorkflowRemoved
+{
+    public function __construct(
+        private readonly string $id,
+    ) {}
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Cloud/Event/Workflow/WorkflowRemoved.php
+++ b/src/Cloud/Event/Workflow/WorkflowRemoved.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kiboko\Component\Satellite\Cloud\Event\Workflow;
 
 class WorkflowRemoved

--- a/src/Cloud/Handler/Pipeline/AddAfterPipelineStepCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/AddAfterPipelineStepCommandHandler.php
@@ -35,11 +35,6 @@ final readonly class AddAfterPipelineStepCommandHandler
             throw new Cloud\AddAfterPipelineStepFailedException('Something went wrong while trying to add a new step after an existing pipeline step. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\AddAfterPipelineStepFailedException('Something went wrong while trying to add a new step after an existing pipeline step.');
-        }
-
         return new Cloud\Event\AddedAfterPipelineStep($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/AddBeforePipelineStepCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/AddBeforePipelineStepCommandHandler.php
@@ -35,11 +35,6 @@ final readonly class AddBeforePipelineStepCommandHandler
             throw new Cloud\AddBeforePipelineStepFailedException('Something went wrong while trying to add a new step before an existing pipeline step. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\AddBeforePipelineStepFailedException('Something went wrong while trying to add a new step before an existing pipeline step.');
-        }
-
         return new Cloud\Event\AddedBeforePipelineStep($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/AddPipelineComposerPSR4AutoloadCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/AddPipelineComposerPSR4AutoloadCommandHandler.php
@@ -30,11 +30,6 @@ final readonly class AddPipelineComposerPSR4AutoloadCommandHandler
             throw new Cloud\AddPipelineComposerPSR4AutoloadFailedException('Something went wrong while trying to add PSR4 autoloads into the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\AddPipelineComposerPSR4AutoloadFailedException('Something went wrong while trying to add PSR4 autoloads into the pipeline.');
-        }
-
         return new Cloud\Event\AddedPipelineComposerPSR4Autoload($result->id, $result->namespace, $result->paths);
     }
 }

--- a/src/Cloud/Handler/Pipeline/AddPipelineStepProbeCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/AddPipelineStepProbeCommandHandler.php
@@ -33,11 +33,6 @@ final readonly class AddPipelineStepProbeCommandHandler
             throw new Cloud\AddPipelineStepProbeFailedException('Something went wrong while trying to add a probe into an existing pipeline step. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\AddPipelineStepProbeFailedException('Something went wrong while trying to add a probe into an existing pipeline step.');
-        }
-
         return new Cloud\Event\AddedPipelineStepProbe($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/AppendPipelineStepCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/AppendPipelineStepCommandHandler.php
@@ -35,11 +35,6 @@ final readonly class AppendPipelineStepCommandHandler
             throw new Cloud\AppendPipelineStepFailedException('Something went wrong while trying to append a pipeline step. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\AppendPipelineStepFailedException('Something went wrong while trying to append a pipeline step.');
-        }
-
         return new Cloud\Event\AppendedPipelineStep($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/CompilePipelineCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/CompilePipelineCommandHandler.php
@@ -28,11 +28,6 @@ final readonly class CompilePipelineCommandHandler
             throw new Cloud\CompilePipelineFailedException('Something went wrong while trying to compile the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\CompilePipelineFailedException('Something went wrong while trying to compile the pipeline.');
-        }
-
         return new Cloud\Event\CompiledPipeline($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/DeclarePipelineCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/DeclarePipelineCommandHandler.php
@@ -33,18 +33,31 @@ final readonly class DeclarePipelineCommandHandler
                                 fn (Probe $probe) => (new Api\Model\Probe())->setCode($probe->code)->setLabel($probe->label))
                             )
                     ))
-                // TODO : implements the composer declaration
-                //                    ->setComposer(),
+                    ->setComposer(
+                        (new Api\Model\Composer())
+                            ->setAutoloads($command->composer->autoload()->map(
+                                fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\ComposerAutoload())
+                                    ->setNamespace($autoloadConfig->namespace)
+                                    ->setPaths($autoloadConfig->paths)
+                            ))
+                            ->setPackages($command->composer->packages()->transform())
+                            ->setAuthentications($command->composer->auths()->map(
+                                fn (Cloud\DTO\Auth $auth) => (new Api\Model\ComposerAuthentication())
+                                    ->setUrl($auth->url)
+                                    ->setToken($auth->token)
+                            ))
+                            ->setRepositories($command->composer->repositories()->map(
+                                fn (Cloud\DTO\Repository $repository) => (new Api\Model\ComposerRepository())
+                                    ->setName($repository->name)
+                                    ->setType($repository->type)
+                                    ->setUrl($repository->url)
+                            ))
+                    ),
             );
         } catch (Api\Exception\DeclarePipelinePipelineCollectionBadRequestException $exception) {
             throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
         } catch (Api\Exception\DeclarePipelinePipelineCollectionUnprocessableEntityException $exception) {
             throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
-        }
-
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline.');
         }
 
         return new Cloud\Event\PipelineDeclared($result->id);

--- a/src/Cloud/Handler/Pipeline/DeclarePipelineCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/DeclarePipelineCommandHandler.php
@@ -7,6 +7,7 @@ namespace Kiboko\Component\Satellite\Cloud\Handler\Pipeline;
 use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud;
 use Kiboko\Component\Satellite\Cloud\DTO\Probe;
+use Kiboko\Component\Satellite\Cloud\DTO\PSR4AutoloadConfig;
 use Kiboko\Component\Satellite\Cloud\DTO\Step;
 
 final readonly class DeclarePipelineCommandHandler

--- a/src/Cloud/Handler/Pipeline/RemovePipelineCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/RemovePipelineCommandHandler.php
@@ -23,11 +23,6 @@ final readonly class RemovePipelineCommandHandler
             throw new Cloud\RemovePipelineFailedException('Something went wrong while trying to remove a step from the pipeline. Maybe you are trying to delete a pipeline that never existed or has already been deleted.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\RemovePipelineFailedException('Something went wrong while trying to remove a step from the pipeline.');
-        }
-
         return new Cloud\Event\RemovedPipeline((string) $command->pipeline);
     }
 }

--- a/src/Cloud/Handler/Pipeline/RemovePipelineStepCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/RemovePipelineStepCommandHandler.php
@@ -26,11 +26,6 @@ final readonly class RemovePipelineStepCommandHandler
             throw new Cloud\RemovePipelineStepFailedException('Something went wrong while trying to remove a probe from the step. Maybe you are trying to delete a step that never existed or has already been deleted.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\RemovePipelineStepFailedException('Something went wrong while trying to remove a probe from the step.');
-        }
-
         return new Cloud\Event\RemovedPipelineStep((string) $command->code);
     }
 }

--- a/src/Cloud/Handler/Pipeline/RemovePipelineStepProbeCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/RemovePipelineStepProbeCommandHandler.php
@@ -28,11 +28,6 @@ final readonly class RemovePipelineStepProbeCommandHandler
             throw new Cloud\RemovePipelineStepProbeFailedException('Something went wrong while removing a probe from the step. Maybe you are trying to delete a probe that never existed or has already been deleted.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\RemovePipelineStepProbeFailedException('Something went wrong while removing a probe from the step.');
-        }
-
         return new Cloud\Event\RemovedPipelineStepProbe($result->id);
     }
 }

--- a/src/Cloud/Handler/Pipeline/ReplacePipelineStepCommandHandler.php
+++ b/src/Cloud/Handler/Pipeline/ReplacePipelineStepCommandHandler.php
@@ -35,11 +35,6 @@ final readonly class ReplacePipelineStepCommandHandler
             throw new Cloud\ReplacePipelineStepFailedException('Something went wrong while replacing a step from the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\ReplacePipelineStepFailedException('Something went wrong while replacing a step from the pipeline.');
-        }
-
         return new Cloud\Event\ReplacedPipelineStep($result->id);
     }
 }

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Handler\Workflow;
+
+use Gyroscops\Api;
+use Kiboko\Component\Satellite\Cloud;
+use Kiboko\Component\Satellite\Cloud\DTO\Probe;
+use Kiboko\Component\Satellite\Cloud\DTO\PSR4AutoloadConfig;
+use Kiboko\Component\Satellite\Cloud\DTO\Step;
+
+final readonly class DeclareWorkflowCommandHandler
+{
+    public function __construct(
+        private Api\Client $client,
+    ) {}
+
+    /** TODO: update this method */
+    public function __invoke(Cloud\Command\Pipeline\DeclarePipelineCommand $command): Cloud\Event\PipelineDeclared
+    {
+        try {
+            /** @var \stdClass $result */
+            $result = $this->client->declarePipelinePipelineCollection(
+                (new Api\Model\PipelineDeclarePipelineCommandInput())
+                    ->setLabel($command->label)
+                    ->setCode($command->code)
+                    ->setSteps($command->steps->map(
+                        fn (Step $step) => (new Api\Model\StepInput())
+                            ->setCode((string) $step->code)
+                            ->setLabel($step->label)
+                            ->setConfiguration($step->config)
+                            ->setProbes($step->probes->map(
+                                fn (Probe $probe) => (new Api\Model\Probe())->setCode($probe->code)->setLabel($probe->label))
+                            )
+                    ))
+                    ->setAutoloads($command->autoload->map(
+                        fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\AutoloadInput())
+                            ->setNamespace($autoloadConfig->namespace)
+                            ->setPaths($autoloadConfig->paths)
+                    ))
+                    ->setPackages($command->packages->transform())
+                    ->setAuths($command->auths->map(
+                        fn (Cloud\DTO\Auth $auth) => (new Api\Model\AddPipelineComposerAuthCommandInput())
+                            ->setUrl($auth->url)
+                            ->setToken($auth->token)
+                    ))
+                    ->setRepositories($command->repositories->map(
+                        fn (Cloud\DTO\Repository $repository) => (new Api\Model\AddPipelineComposerRepositoryCommandInput())
+                            ->setName($repository->name)
+                            ->setType($repository->type)
+                            ->setUrl($repository->url)
+                    )),
+            );
+        } catch (Api\Exception\DeclarePipelinePipelineCollectionBadRequestException $exception) {
+            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
+        } catch (Api\Exception\DeclarePipelinePipelineCollectionUnprocessableEntityException $exception) {
+            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
+        }
+
+        if (null === $result) {
+            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
+            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline.');
+        }
+
+        return new Cloud\Event\PipelineDeclared($result->id);
+    }
+}

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -24,18 +24,18 @@ final readonly class DeclareWorkflowCommandHandler
                     ->setCode($command->code)
                     ->setComposer(
                         (new Api\Model\Composer())
-                            ->setAutoloads($command->autoload->map(
+                            ->setAutoloads($command->composer->autoload()->map(
                                 fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\ComposerAutoload())
                                     ->setNamespace($autoloadConfig->namespace)
                                     ->setPaths($autoloadConfig->paths)
                             ))
-                            ->setPackages($command->packages->transform())
-                            ->setAuthentications($command->auths->map(
+                            ->setPackages($command->composer->packages()->transform())
+                            ->setAuthentications($command->composer->auths()->map(
                                 fn (Cloud\DTO\Auth $auth) => (new Api\Model\ComposerAuthentication())
                                     ->setUrl($auth->url)
                                     ->setToken($auth->token)
                             ))
-                            ->setRepositories($command->repositories->map(
+                            ->setRepositories($command->composer->repositories()->map(
                                 fn (Cloud\DTO\Repository $repository) => (new Api\Model\ComposerRepository())
                                     ->setName($repository->name)
                                     ->setType($repository->type)

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -16,7 +16,6 @@ final readonly class DeclareWorkflowCommandHandler
 
     public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command): Cloud\Event\Workflow\WorkflowDeclared
     {
-        $result = null;
         try {
             /** @var Api\Model\WorkflowDeclareWorkflowCommandJsonldRead $result */
             $result = $this->client->declareWorkflowWorkflowCollection(
@@ -42,14 +41,46 @@ final readonly class DeclareWorkflowCommandHandler
                                     ->setType($repository->type)
                                     ->setUrl($repository->url)
                             ))
-                    ),
+                    )
+                ->setJobs(
+                    $command->jobs->map(
+                        function (Cloud\DTO\Workflow\JobInterface $job) {
+                            if ($job instanceof Cloud\DTO\Workflow\Pipeline) {
+                                return (new Api\Model\Job())
+                                    ->setCode($job->code->asString())
+                                    ->setLabel($job->label)
+                                    ->setPipeline(
+                                        (new Api\Model\Pipeline())
+                                            ->setSteps(
+                                                $job->stepList->map(
+                                                    fn (Cloud\DTO\Step $step) => (new Api\Model\Step())
+                                                        ->setCode($step->code->asString())
+                                                        ->setLabel($step->label)
+                                                        ->setConfiguration($step->config)
+                                                )
+                                            )
+                                    );
+                            }
+
+                            if ($job instanceof Cloud\DTO\Workflow\Action) {
+                                return (new Api\Model\Job())
+                                    ->setCode($job->code->asString())
+                                    ->setLabel($job->label)
+                                    ->setAction(
+                                        (new Api\Model\Action())
+                                            ->setConfiguration($job->configuration)
+                                    );
+                            }
+
+                            throw new \RuntimeException('Unexpected instance of PipelineInterface.');
+                        }
+                    )
+                ),
             );
         } catch (Api\Exception\DeclareWorkflowWorkflowCollectionBadRequestException $exception) {
-            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
+            throw new Cloud\DeclareWorkflowFailedException('Something went wrong while declaring the workflow. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
         } catch (Api\Exception\DeclareWorkflowWorkflowCollectionUnprocessableEntityException $exception) {
-            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
-        } catch (\Exception $exception) {
-            var_dump($exception);
+            throw new Cloud\DeclareWorkflowFailedException('Something went wrong while declaring the workflow. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
         return new Cloud\Event\Workflow\WorkflowDeclared($result->getId());

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -59,7 +59,8 @@ final readonly class DeclareWorkflowCommandHandler
                                                         ->setConfiguration($step->config)
                                                 )
                                             )
-                                    );
+                                    )
+                                ;
                             }
 
                             if ($job instanceof Cloud\DTO\Workflow\Action) {
@@ -69,7 +70,8 @@ final readonly class DeclareWorkflowCommandHandler
                                     ->setAction(
                                         (new Api\Model\Action())
                                             ->setConfiguration($job->configuration)
-                                    );
+                                    )
+                                ;
                             }
 
                             throw new \RuntimeException('Unexpected instance of PipelineInterface.');
@@ -81,6 +83,11 @@ final readonly class DeclareWorkflowCommandHandler
             throw new Cloud\DeclareWorkflowFailedException('Something went wrong while declaring the workflow. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
         } catch (Api\Exception\DeclareWorkflowWorkflowCollectionUnprocessableEntityException $exception) {
             throw new Cloud\DeclareWorkflowFailedException('Something went wrong while declaring the workflow. It seems the data you sent was invalid, please check your input.', previous: $exception);
+        }
+
+        /* TODO : we need to remove this condition from this class and fix the Authentication checker */
+        if (null == $result) {
+            throw new \RuntimeException('Your token has expired, please refresh it.');
         }
 
         return new Cloud\Event\Workflow\WorkflowDeclared($result->getId());

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -85,11 +85,6 @@ final readonly class DeclareWorkflowCommandHandler
             throw new Cloud\DeclareWorkflowFailedException('Something went wrong while declaring the workflow. It seems the data you sent was invalid, please check your input.', previous: $exception);
         }
 
-        /* TODO : we need to remove this condition from this class and fix the Authentication checker */
-        if (null == $result) {
-            throw new \RuntimeException('Your token has expired, please refresh it.');
-        }
-
         return new Cloud\Event\Workflow\WorkflowDeclared($result->getId());
     }
 }

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -27,6 +27,7 @@ final readonly class DeclareWorkflowCommandHandler
                             ->setAutoloads($command->composer->autoload()->map(
                                 fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\ComposerAutoload())
                                     ->setNamespace($autoloadConfig->namespace)
+                                    ->setType('psr-4')
                                     ->setPaths($autoloadConfig->paths)
                             ))
                             ->setPackages($command->composer->packages()->transform())

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -16,6 +16,7 @@ final readonly class DeclareWorkflowCommandHandler
 
     public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command): Cloud\Event\Workflow\WorkflowDeclared
     {
+        $result = null;
         try {
             /** @var Api\Model\WorkflowDeclareWorkflowCommandJsonldRead $result */
             $result = $this->client->declareWorkflowWorkflowCollection(

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -12,7 +12,8 @@ final readonly class DeclareWorkflowCommandHandler
 {
     public function __construct(
         private Api\Client $client,
-    ) {}
+    ) {
+    }
 
     public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command): Cloud\Event\Workflow\WorkflowDeclared
     {

--- a/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/DeclareWorkflowCommandHandler.php
@@ -6,9 +6,7 @@ namespace Kiboko\Component\Satellite\Cloud\Handler\Workflow;
 
 use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud;
-use Kiboko\Component\Satellite\Cloud\DTO\Probe;
 use Kiboko\Component\Satellite\Cloud\DTO\PSR4AutoloadConfig;
-use Kiboko\Component\Satellite\Cloud\DTO\Step;
 
 final readonly class DeclareWorkflowCommandHandler
 {
@@ -16,53 +14,43 @@ final readonly class DeclareWorkflowCommandHandler
         private Api\Client $client,
     ) {}
 
-    /** TODO: update this method */
-    public function __invoke(Cloud\Command\Pipeline\DeclarePipelineCommand $command): Cloud\Event\PipelineDeclared
+    public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command): Cloud\Event\Workflow\WorkflowDeclared
     {
         try {
-            /** @var \stdClass $result */
-            $result = $this->client->declarePipelinePipelineCollection(
-                (new Api\Model\PipelineDeclarePipelineCommandInput())
+            /** @var Api\Model\WorkflowDeclareWorkflowCommandJsonldRead $result */
+            $result = $this->client->declareWorkflowWorkflowCollection(
+                (new Api\Model\WorkflowDeclareWorkflowCommandInput())
                     ->setLabel($command->label)
                     ->setCode($command->code)
-                    ->setSteps($command->steps->map(
-                        fn (Step $step) => (new Api\Model\StepInput())
-                            ->setCode((string) $step->code)
-                            ->setLabel($step->label)
-                            ->setConfiguration($step->config)
-                            ->setProbes($step->probes->map(
-                                fn (Probe $probe) => (new Api\Model\Probe())->setCode($probe->code)->setLabel($probe->label))
-                            )
-                    ))
-                    ->setAutoloads($command->autoload->map(
-                        fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\AutoloadInput())
-                            ->setNamespace($autoloadConfig->namespace)
-                            ->setPaths($autoloadConfig->paths)
-                    ))
-                    ->setPackages($command->packages->transform())
-                    ->setAuths($command->auths->map(
-                        fn (Cloud\DTO\Auth $auth) => (new Api\Model\AddPipelineComposerAuthCommandInput())
-                            ->setUrl($auth->url)
-                            ->setToken($auth->token)
-                    ))
-                    ->setRepositories($command->repositories->map(
-                        fn (Cloud\DTO\Repository $repository) => (new Api\Model\AddPipelineComposerRepositoryCommandInput())
-                            ->setName($repository->name)
-                            ->setType($repository->type)
-                            ->setUrl($repository->url)
-                    )),
+                    ->setComposer(
+                        (new Api\Model\Composer())
+                            ->setAutoloads($command->autoload->map(
+                                fn (PSR4AutoloadConfig $autoloadConfig) => (new Api\Model\ComposerAutoload())
+                                    ->setNamespace($autoloadConfig->namespace)
+                                    ->setPaths($autoloadConfig->paths)
+                            ))
+                            ->setPackages($command->packages->transform())
+                            ->setAuthentications($command->auths->map(
+                                fn (Cloud\DTO\Auth $auth) => (new Api\Model\ComposerAuthentication())
+                                    ->setUrl($auth->url)
+                                    ->setToken($auth->token)
+                            ))
+                            ->setRepositories($command->repositories->map(
+                                fn (Cloud\DTO\Repository $repository) => (new Api\Model\ComposerRepository())
+                                    ->setName($repository->name)
+                                    ->setType($repository->type)
+                                    ->setUrl($repository->url)
+                            ))
+                    ),
             );
-        } catch (Api\Exception\DeclarePipelinePipelineCollectionBadRequestException $exception) {
+        } catch (Api\Exception\DeclareWorkflowWorkflowCollectionBadRequestException $exception) {
             throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
-        } catch (Api\Exception\DeclarePipelinePipelineCollectionUnprocessableEntityException $exception) {
+        } catch (Api\Exception\DeclareWorkflowWorkflowCollectionUnprocessableEntityException $exception) {
             throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline. It seems the data you sent was invalid, please check your input.', previous: $exception);
+        } catch (\Exception $exception) {
+            var_dump($exception);
         }
 
-        if (null === $result) {
-            // TODO: change the exception message, it doesn't give enough details on how to fix the issue
-            throw new Cloud\DeclarePipelineFailedException('Something went wrong while declaring the pipeline.');
-        }
-
-        return new Cloud\Event\PipelineDeclared($result->id);
+        return new Cloud\Event\Workflow\WorkflowDeclared($result->getId());
     }
 }

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -4,17 +4,31 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud\Handler\Workflow;
 
+use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud;
 
-final class RemoveWorkflowCommandHandler
+final readonly class RemoveWorkflowCommandHandler
 {
     public function __construct(
-        \Gyroscops\Api\Client $client,
+        private \Gyroscops\Api\Client $client,
     ) {
     }
 
-    public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command)
+    public function __invoke(Cloud\Command\Workflow\RemoveWorkflowCommand $command): Cloud\Event\Workflow\WorkflowRemoved
     {
+        try {
+            /** @var Api\Model\WorkflowRemoveWorkflowCommandJsonldRead $result */
+            $result = $this->client->softDeleteWorkflowItem(
+                $command->id->asString()
+            );
+        } catch (Api\Exception\SoftDeleteWorkflowItemBadRequestException $exception) {
+            throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. Maybe your client is not up to date, you may want to update your Gyroscops client.', previous: $exception);
+        } catch (Api\Exception\SoftDeleteWorkflowItemUnprocessableEntityException $exception) {
+            throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. It seems the data you sent was invalid, please check your input.', previous: $exception);
+        } catch (Api\Exception\SoftDeleteWorkflowItemNotFoundException $exception) {
+            throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. It seems the data you want to delete do not exists.', previous: $exception);
+        }
 
+        return new Cloud\Event\Workflow\WorkflowRemoved($result->getId());
     }
 }

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -11,8 +11,7 @@ final readonly class RemoveWorkflowCommandHandler
 {
     public function __construct(
         private \Gyroscops\Api\Client $client,
-    ) {
-    }
+    ) {}
 
     public function __invoke(Cloud\Command\Workflow\RemoveWorkflowCommand $command): Cloud\Event\Workflow\WorkflowRemoved
     {
@@ -27,6 +26,11 @@ final readonly class RemoveWorkflowCommandHandler
             throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. It seems the data you sent was invalid, please check your input.', previous: $exception);
         } catch (Api\Exception\SoftDeleteWorkflowItemNotFoundException $exception) {
             throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. It seems the data you want to delete do not exists.', previous: $exception);
+        }
+
+        /* TODO : we need to remove this condition from this class and fix the Authentication checker */
+        if (null == $result) {
+            throw new \RuntimeException('Your token has expired, please refresh it.');
         }
 
         return new Cloud\Event\Workflow\WorkflowRemoved($result->getId());

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -10,7 +10,7 @@ use Kiboko\Component\Satellite\Cloud;
 final readonly class RemoveWorkflowCommandHandler
 {
     public function __construct(
-        private \Gyroscops\Api\Client $client,
+        private Api\Client $client,
     ) {
     }
 

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -11,7 +11,8 @@ final readonly class RemoveWorkflowCommandHandler
 {
     public function __construct(
         private \Gyroscops\Api\Client $client,
-    ) {}
+    ) {
+    }
 
     public function __invoke(Cloud\Command\Workflow\RemoveWorkflowCommand $command): Cloud\Event\Workflow\WorkflowRemoved
     {

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud\Handler\Workflow;
+
+use Kiboko\Component\Satellite\Cloud;
+
+final class RemoveWorkflowCommandHandler
+{
+    public function __construct(
+        \Gyroscops\Api\Client $client,
+    ) {
+    }
+
+    public function __invoke(Cloud\Command\Workflow\DeclareWorkflowCommand $command)
+    {
+
+    }
+}

--- a/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
+++ b/src/Cloud/Handler/Workflow/RemoveWorkflowCommandHandler.php
@@ -28,11 +28,6 @@ final readonly class RemoveWorkflowCommandHandler
             throw new Cloud\RemoveWorkflowFailedException('Something went wrong while removing the workflow. It seems the data you want to delete do not exists.', previous: $exception);
         }
 
-        /* TODO : we need to remove this condition from this class and fix the Authentication checker */
-        if (null == $result) {
-            throw new \RuntimeException('Your token has expired, please refresh it.');
-        }
-
         return new Cloud\Event\Workflow\WorkflowRemoved($result->getId());
     }
 }

--- a/src/Cloud/Pipeline.php
+++ b/src/Cloud/Pipeline.php
@@ -6,6 +6,7 @@ namespace Kiboko\Component\Satellite\Cloud;
 
 use Gyroscops\Api;
 use Kiboko\Component\Satellite\Cloud\DTO\AuthList;
+use Kiboko\Component\Satellite\Cloud\DTO\Composer;
 use Kiboko\Component\Satellite\Cloud\DTO\Package;
 use Kiboko\Component\Satellite\Cloud\DTO\PipelineId;
 use Kiboko\Component\Satellite\Cloud\DTO\ProbeList;
@@ -51,34 +52,36 @@ final readonly class Pipeline implements PipelineInterface
                     );
                 }, $configuration['pipeline']['steps'], range(0, (is_countable($configuration['pipeline']['steps']) ? \count($configuration['pipeline']['steps']) : 0) - 1))
             ),
-            new DTO\Autoload(
-                ...array_map(
-                    fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
-                    array_keys($configuration['composer']['autoload']['psr4'] ?? []),
-                    $configuration['composer']['autoload']['psr4'] ?? [],
-                )
-            ),
-            new DTO\PackageList(
-                ...array_map(
-                    function (string $namespace) {
-                        $parts = explode(':', $namespace);
+            new Composer(
+                new DTO\Autoload(
+                    ...array_map(
+                        fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
+                        array_keys($configuration['composer']['autoload']['psr4'] ?? []),
+                        $configuration['composer']['autoload']['psr4'] ?? [],
+                    )
+                ),
+                new DTO\PackageList(
+                    ...array_map(
+                        function (string $namespace) {
+                            $parts = explode(':', $namespace);
 
-                        return new Package($parts[0], $parts[1]);
-                    },
-                    $configuration['composer']['require'] ?? [],
-                )
-            ),
-            new RepositoryList(
-                ...array_map(
-                    fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
-                    $configuration['composer']['repositories'] ?? [],
-                )
-            ),
-            new AuthList(
-                ...array_map(
-                    fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
-                    $configuration['composer']['auth'] ?? [],
-                )
+                            return new Package($parts[0], $parts[1]);
+                        },
+                        $configuration['composer']['require'] ?? [],
+                    )
+                ),
+                new RepositoryList(
+                    ...array_map(
+                        fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
+                        $configuration['composer']['repositories'] ?? [],
+                    )
+                ),
+                new AuthList(
+                    ...array_map(
+                        fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
+                        $configuration['composer']['auth'] ?? [],
+                    )
+                ),
             ),
         );
     }
@@ -150,56 +153,55 @@ final readonly class Pipeline implements PipelineInterface
                     );
                 }, $steps, range(0, \count($steps)))
             ),
-            new DTO\Autoload(
-                ...array_map(
-                    fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
-                    array_keys($configuration['composer']['autoload']['psr4'] ?? []),
-                    $model->getAutoload(),
-                )
-            ),
-            new DTO\PackageList(
-                ...array_map(
-                    function (string $namespace) {
-                        $parts = explode(':', $namespace);
+            new Composer(
+                new DTO\Autoload(
+                    ...array_map(
+                        fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
+                        array_keys($configuration['composer']['autoload']['psr4'] ?? []),
+                        $model->getAutoload(),
+                    )
+                ),
+                new DTO\PackageList(
+                    ...array_map(
+                        function (string $namespace) {
+                            $parts = explode(':', $namespace);
 
-                        return new Package($parts[0], $parts[1]);
-                    },
-                    $model->getPackages(),
-                )
-            ),
-            new RepositoryList(
-                ...array_map(
-                    fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
-                    $model->getRepositories(),
-                )
-            ),
-            new AuthList(
-                ...array_map(
-                    fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
-                    $model->getAuths(),
-                )
+                            return new Package($parts[0], $parts[1]);
+                        },
+                        $model->getPackages(),
+                    )
+                ),
+                new RepositoryList(
+                    ...array_map(
+                        fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
+                        $model->getRepositories(),
+                    )
+                ),
+                new AuthList(
+                    ...array_map(
+                        fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
+                        $model->getAuths(),
+                    )
+                ),
             ),
         );
     }
 
-    public function create(DTO\PipelineInterface $pipeline): DTO\CommandBatch
+    public function create(DTO\SatelliteInterface&DTO\PipelineInterface $pipeline): DTO\CommandBatch
     {
         return new DTO\CommandBatch(
             new Command\Pipeline\DeclarePipelineCommand(
                 $pipeline->code(),
                 $pipeline->label(),
                 $pipeline->steps(),
-                $pipeline->autoload(),
-                $pipeline->packages(),
-                $pipeline->repositories(),
-                $pipeline->auths(),
+                $pipeline->composer(),
                 $this->context->organization(),
                 $this->context->workspace(),
             )
         );
     }
 
-    public function update(ReferencedPipeline $actual, DTO\PipelineInterface $desired): DTO\CommandBatch
+    public function update(ReferencedPipeline $actual, DTO\SatelliteInterface&DTO\PipelineInterface $desired): DTO\CommandBatch
     {
         if ($actual->code() !== $desired->code()) {
             throw new \RuntimeException('Code does not match between actual and desired pipeline definition.');
@@ -213,7 +215,7 @@ final readonly class Pipeline implements PipelineInterface
         $commands = $diff->diff($actual->steps(), $desired->steps());
 
         // Check the changes in the list of autoloads
-        if (\count($actual->autoload()) !== \count($desired->autoload())) {
+        if (\count($actual->autoload()) !== \count($desired->composer()->autoload())) {
             // TODO: make diff of the autoload
         }
 

--- a/src/Cloud/Pipeline.php
+++ b/src/Cloud/Pipeline.php
@@ -187,7 +187,7 @@ final readonly class Pipeline implements PipelineInterface
         );
     }
 
-    public function create(DTO\SatelliteInterface&DTO\PipelineInterface $pipeline): DTO\CommandBatch
+    public function create(DTO\PipelineInterface&DTO\SatelliteInterface $pipeline): DTO\CommandBatch
     {
         return new DTO\CommandBatch(
             new Command\Pipeline\DeclarePipelineCommand(
@@ -201,7 +201,7 @@ final readonly class Pipeline implements PipelineInterface
         );
     }
 
-    public function update(ReferencedPipeline $actual, DTO\SatelliteInterface&DTO\PipelineInterface $desired): DTO\CommandBatch
+    public function update(ReferencedPipeline $actual, DTO\PipelineInterface&DTO\SatelliteInterface $desired): DTO\CommandBatch
     {
         if ($actual->code() !== $desired->code()) {
             throw new \RuntimeException('Code does not match between actual and desired pipeline definition.');

--- a/src/Cloud/Pipeline.php
+++ b/src/Cloud/Pipeline.php
@@ -28,7 +28,7 @@ final readonly class Pipeline implements PipelineInterface
 
         return new DTO\Pipeline(
             $configuration['pipeline']['name'] ?? sprintf('Pipeline %s', $random),
-            $configuration['pipeline']['code'] ?? sprintf('pipeline_%s', $random),
+            $configuration['code'] ?? sprintf('pipeline_%s', $random),
             new DTO\StepList(
                 ...array_map(function (array $stepConfig, int $order) {
                     $name = $stepConfig['name'] ?? sprintf('step%d', $order);

--- a/src/Cloud/PipelineInterface.php
+++ b/src/Cloud/PipelineInterface.php
@@ -15,9 +15,9 @@ interface PipelineInterface
 
     public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedPipeline;
 
-    public function create(DTO\PipelineInterface $pipeline): DTO\CommandBatch;
+    public function create(DTO\SatelliteInterface&DTO\PipelineInterface $pipeline): DTO\CommandBatch;
 
-    public function update(DTO\ReferencedPipeline $actual, DTO\PipelineInterface $desired): DTO\CommandBatch;
+    public function update(DTO\ReferencedPipeline $actual, DTO\SatelliteInterface&DTO\PipelineInterface $desired): DTO\CommandBatch;
 
     public function remove(PipelineId $id): DTO\CommandBatch;
 }

--- a/src/Cloud/PipelineInterface.php
+++ b/src/Cloud/PipelineInterface.php
@@ -15,9 +15,9 @@ interface PipelineInterface
 
     public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedPipeline;
 
-    public function create(DTO\SatelliteInterface&DTO\PipelineInterface $pipeline): DTO\CommandBatch;
+    public function create(DTO\PipelineInterface&DTO\SatelliteInterface $pipeline): DTO\CommandBatch;
 
-    public function update(DTO\ReferencedPipeline $actual, DTO\SatelliteInterface&DTO\PipelineInterface $desired): DTO\CommandBatch;
+    public function update(DTO\ReferencedPipeline $actual, DTO\PipelineInterface&DTO\SatelliteInterface $desired): DTO\CommandBatch;
 
     public function remove(PipelineId $id): DTO\CommandBatch;
 }

--- a/src/Cloud/RemoveWorkflowFailedException.php
+++ b/src/Cloud/RemoveWorkflowFailedException.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud;
+
+class RemoveWorkflowFailedException extends \RuntimeException {}

--- a/src/Cloud/RemoveWorkflowFailedException.php
+++ b/src/Cloud/RemoveWorkflowFailedException.php
@@ -4,4 +4,6 @@ declare(strict_types=1);
 
 namespace Kiboko\Component\Satellite\Cloud;
 
-class RemoveWorkflowFailedException extends \RuntimeException {}
+class RemoveWorkflowFailedException extends \RuntimeException
+{
+}

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -31,7 +31,7 @@ final readonly class Workflow implements WorkflowInterface
 
         return new DTO\Workflow(
             $configuration['workflow']['name'] ?? sprintf('Workflow %s', $random),
-            $configuration['workflow']['code'] ?? sprintf('workflow_%s', $random),
+            $configuration['code'] ?? sprintf('workflow_%s', $random),
             new DTO\JobList(
                 ...array_map(
                     function (array $config, int $order) {

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -76,6 +76,10 @@ final readonly class Workflow implements WorkflowInterface
                                 }
                             });
 
+                            $configuration = $config["action"];
+                            unset($config["action"]);
+                            $config += $configuration;
+
                             return new DTO\Workflow\Action(
                                 $name,
                                 new JobCode($code),

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -128,7 +128,7 @@ final readonly class Workflow implements WorkflowInterface
         );
     }
 
-    public static function fromApiWithId(Api\Client $client, WorkflowId $id): DTO\ReferencedWorkflow
+    public static function fromApiWithId(Api\Client $client, WorkflowId $id): ReferencedWorkflow
     {
         /** @var Api\Model\WorkflowJsonldRead|Api\Model\WorkflowRead $item */
         $item = $client->getWorkflowItem($id->asString());
@@ -145,7 +145,7 @@ final readonly class Workflow implements WorkflowInterface
         );
     }
 
-    public static function fromApiWithCode(Api\Client $client, string $code): DTO\ReferencedWorkflow
+    public static function fromApiWithCode(Api\Client $client, string $code): ReferencedWorkflow
     {
         $collection = $client->getWorkflowCollection(['code' => $code]);
 
@@ -258,7 +258,7 @@ final readonly class Workflow implements WorkflowInterface
         );
     }
 
-    public function update(DTO\ReferencedWorkflow $actual, DTO\SatelliteInterface&DTO\WorkflowInterface $desired): DTO\CommandBatch
+    public function update(ReferencedWorkflow $actual, DTO\SatelliteInterface&DTO\WorkflowInterface $desired): DTO\CommandBatch
     {
         if ($actual->code() !== $desired->code()) {
             throw new \RuntimeException('Code does not match between actual and desired workflow definition.');
@@ -273,7 +273,7 @@ final readonly class Workflow implements WorkflowInterface
         return new DTO\CommandBatch(...$commands);
     }
 
-    public function remove(DTO\WorkflowId $id): DTO\CommandBatch
+    public function remove(WorkflowId $id): DTO\CommandBatch
     {
         return new DTO\CommandBatch(
             new Command\Workflow\RemoveWorkflowCommand($id),

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -31,7 +31,7 @@ final readonly class Workflow implements WorkflowInterface
 
         return new DTO\Workflow(
             $configuration['workflow']['name'] ?? sprintf('Workflow %s', $random),
-            $configuration['code'] ?? sprintf('workflow_%s', $random),
+            $configuration['code'] ?? sprintf('workflow%s', $random),
             new DTO\JobList(
                 ...array_map(
                     function (array $config, int $order) {
@@ -66,8 +66,8 @@ final readonly class Workflow implements WorkflowInterface
                         }
 
                         if (\array_key_exists('action', $config)) {
-                            $name = $config['action']['name'] ?? sprintf('pipeline%d', $order);
-                            $code = $config['action']['code'] ?? sprintf('pipeline%d', $order);
+                            $name = $config['action']['name'] ?? sprintf('action%d', $order);
+                            $code = $config['action']['code'] ?? sprintf('action%d', $order);
                             unset($config['action']['name'], $config['action']['code']);
 
                             array_walk_recursive($config, function (&$value): void {

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -9,7 +9,6 @@ use Kiboko\Component\Satellite\Cloud\DTO\AuthList;
 use Kiboko\Component\Satellite\Cloud\DTO\Composer;
 use Kiboko\Component\Satellite\Cloud\DTO\JobCode;
 use Kiboko\Component\Satellite\Cloud\DTO\Package;
-use Kiboko\Component\Satellite\Cloud\DTO\Probe;
 use Kiboko\Component\Satellite\Cloud\DTO\ProbeList;
 use Kiboko\Component\Satellite\Cloud\DTO\ReferencedWorkflow;
 use Kiboko\Component\Satellite\Cloud\DTO\RepositoryList;
@@ -76,8 +75,8 @@ final readonly class Workflow implements WorkflowInterface
                                 }
                             });
 
-                            $configuration = $config["action"];
-                            unset($config["action"]);
+                            $configuration = $config['action'];
+                            unset($config['action']);
                             $config += $configuration;
 
                             return new DTO\Workflow\Action(
@@ -187,7 +186,7 @@ final readonly class Workflow implements WorkflowInterface
                                     $step->getLabel(),
                                     new StepCode($step->getCode()),
                                     $step->getConfiguration(),
-                                    /** TODO : implement probes when it is enabled */
+                                    /* TODO : implement probes when it is enabled */
                                     new ProbeList(),
                                     $order
                                 ),

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -22,7 +22,8 @@ final readonly class Workflow implements WorkflowInterface
 {
     public function __construct(
         private Context $context,
-    ) {}
+    ) {
+    }
 
     public static function fromLegacyConfiguration(array $configuration): DTO\Workflow
     {

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud;
+
+use Gyroscops\Api;
+use Kiboko\Component\Satellite\Cloud\DTO\AuthList;
+use Kiboko\Component\Satellite\Cloud\DTO\Package;
+use Kiboko\Component\Satellite\Cloud\DTO\PipelineId;
+use Kiboko\Component\Satellite\Cloud\DTO\ProbeList;
+use Kiboko\Component\Satellite\Cloud\DTO\ReferencedPipeline;
+use Kiboko\Component\Satellite\Cloud\DTO\RepositoryList;
+use Kiboko\Component\Satellite\Cloud\DTO\StepCode;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+final readonly class Workflow implements PipelineInterface
+{
+    public function __construct(
+        private Context $context,
+    ) {}
+
+    public static function fromLegacyConfiguration(array $configuration): DTO\Pipeline
+    {
+        $random = bin2hex(random_bytes(4));
+
+        return new DTO\Pipeline(
+            $configuration['pipeline']['name'] ?? sprintf('Pipeline %s', $random),
+            $configuration['pipeline']['code'] ?? sprintf('pipeline_%s', $random),
+            new DTO\StepList(
+                ...array_map(function (array $stepConfig, int $order) {
+                    $name = $stepConfig['name'] ?? sprintf('step%d', $order);
+                    $code = $stepConfig['code'] ?? sprintf('step%d', $order);
+                    unset($stepConfig['name'], $stepConfig['code']);
+
+                    array_walk_recursive($stepConfig, function (&$value): void {
+                        if ($value instanceof Expression) {
+                            $value = '@='.$value;
+                        }
+                    });
+
+                    return new DTO\Step(
+                        $name,
+                        new StepCode($code),
+                        $stepConfig,
+                        new ProbeList(
+                            // FIXME: add probes
+                        ),
+                        $order,
+                    );
+                }, $configuration['pipeline']['steps'], range(0, (is_countable($configuration['pipeline']['steps']) ? \count($configuration['pipeline']['steps']) : 0) - 1))
+            ),
+            new DTO\Autoload(
+                ...array_map(
+                    fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
+                    array_keys($configuration['composer']['autoload']['psr4'] ?? []),
+                    $configuration['composer']['autoload']['psr4'] ?? [],
+                )
+            ),
+            new DTO\PackageList(
+                ...array_map(
+                    function (string $namespace) {
+                        $parts = explode(':', $namespace);
+
+                        return new Package($parts[0], $parts[1]);
+                    },
+                    $configuration['composer']['require'] ?? [],
+                )
+            ),
+            new RepositoryList(
+                ...array_map(
+                    fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
+                    $configuration['composer']['repositories'] ?? [],
+                )
+            ),
+            new AuthList(
+                ...array_map(
+                    fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
+                    $configuration['composer']['auth'] ?? [],
+                )
+            ),
+        );
+    }
+
+    public static function fromApiWithId(Api\Client $client, PipelineId $id, array $configuration): DTO\ReferencedPipeline
+    {
+        $item = $client->getPipelineItem($id->asString());
+
+        try {
+            \assert($item instanceof Api\Model\PipelineRead);
+        } catch (\AssertionError) {
+            throw new AccessDeniedException('Could not retrieve the pipeline.');
+        }
+
+        return new ReferencedPipeline(
+            new PipelineId($item->getId()),
+            self::fromApiModel($client, $item, $configuration)
+        );
+    }
+
+    public static function fromApiWithCode(Api\Client $client, string $code, array $configuration): DTO\ReferencedPipeline
+    {
+        $collection = $client->getPipelineCollection(['code' => $code]);
+
+        try {
+            \assert(\is_array($collection));
+        } catch (\AssertionError) {
+            throw new AccessDeniedException('Could not retrieve the pipeline.');
+        }
+        try {
+            \assert(1 === \count($collection));
+            \assert($collection[0] instanceof Api\Model\PipelineRead);
+        } catch (\AssertionError) {
+            throw new \OverflowException('There seems to be several pipelines with the same code, please contact your Customer Success Manager.');
+        }
+
+        return new ReferencedPipeline(
+            new PipelineId($collection[0]->getId()),
+            self::fromApiModel($client, $collection[0], $configuration)
+        );
+    }
+
+    private static function fromApiModel(Api\Client $client, Api\Model\PipelineRead $model, array $configuration): DTO\Pipeline
+    {
+        $steps = $client->apiPipelineStepsProbesGetSubresourcePipelineStepSubresource($model->getId());
+
+        try {
+            \assert(\is_array($steps));
+        } catch (\AssertionError) {
+            throw new AccessDeniedException('Could not retrieve the pipeline steps.');
+        }
+
+        return new DTO\Pipeline(
+            $model->getLabel(),
+            $model->getCode(),
+            new DTO\StepList(
+                ...array_map(function (Api\Model\PipelineStep $step, int $order) use ($client) {
+                    $probes = $client->apiPipelineStepsProbesGetSubresourcePipelineStepSubresource($step->getId());
+
+                    return new DTO\Step(
+                        $step->getLabel(),
+                        new StepCode($step->getCode()),
+                        $step->getConfiguration(),
+                        new ProbeList(
+                            ...array_map(fn (Api\Model\PipelineStepProbe $probe) => new DTO\Probe($probe->getLabel(), $probe->getCode(), $probe->getOrder()), $probes)
+                        ),
+                        $order
+                    );
+                }, $steps, range(0, \count($steps)))
+            ),
+            new DTO\Autoload(
+                ...array_map(
+                    fn (string $namespace, array $paths): DTO\PSR4AutoloadConfig => new DTO\PSR4AutoloadConfig($namespace, ...$paths['paths']),
+                    array_keys($configuration['composer']['autoload']['psr4'] ?? []),
+                    $model->getAutoload(),
+                )
+            ),
+            new DTO\PackageList(
+                ...array_map(
+                    function (string $namespace) {
+                        $parts = explode(':', $namespace);
+
+                        return new Package($parts[0], $parts[1]);
+                    },
+                    $model->getPackages(),
+                )
+            ),
+            new RepositoryList(
+                ...array_map(
+                    fn (array $repository): DTO\Repository => new DTO\Repository($repository['name'], $repository['type'], $repository['url']),
+                    $model->getRepositories(),
+                )
+            ),
+            new AuthList(
+                ...array_map(
+                    fn (array $repository): DTO\Auth => new DTO\Auth($repository['url'], $repository['token']),
+                    $model->getAuths(),
+                )
+            ),
+        );
+    }
+
+    public function create(DTO\PipelineInterface $pipeline): DTO\CommandBatch
+    {
+        return new DTO\CommandBatch(
+            new Command\Pipeline\DeclarePipelineCommand(
+                $pipeline->code(),
+                $pipeline->label(),
+                $pipeline->steps(),
+                $pipeline->autoload(),
+                $pipeline->packages(),
+                $pipeline->repositories(),
+                $pipeline->auths(),
+                $this->context->organization(),
+                $this->context->workspace(),
+            )
+        );
+    }
+
+    public function update(DTO\ReferencedPipeline $actual, DTO\PipelineInterface $desired): DTO\CommandBatch
+    {
+        if ($actual->code() !== $desired->code()) {
+            throw new \RuntimeException('Code does not match between actual and desired pipeline definition.');
+        }
+        if ($actual->label() !== $desired->label()) {
+            throw new \RuntimeException('Label does not match between actual and desired pipeline definition.');
+        }
+
+        // Check the changes in the list of steps
+        $diff = new Diff\StepListDiff($actual->id());
+        $commands = $diff->diff($actual->steps(), $desired->steps());
+
+        // Check the changes in the list of autoloads
+        if (\count($actual->autoload()) !== \count($desired->autoload())) {
+            // TODO: make diff of the autoload
+        }
+
+        return new DTO\CommandBatch(...$commands);
+    }
+
+    public function remove(DTO\PipelineId $id): DTO\CommandBatch
+    {
+        return new DTO\CommandBatch(
+            new Command\Pipeline\RemovePipelineCommand($id),
+        );
+    }
+}

--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -189,7 +189,7 @@ final readonly class Workflow implements WorkflowInterface
                     }
 
                     throw new \RuntimeException('This type of job is not currently supported.');
-                }, $jobs = $workflow->getJobs(), range(0, \count($jobs)))
+                }, $jobs = $workflow->getJobs(), range(0, \count((array) $jobs)))
             ),
             new DTO\Autoload(
                 ...array_map(

--- a/src/Cloud/WorkflowInterface.php
+++ b/src/Cloud/WorkflowInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kiboko\Component\Satellite\Cloud;
+
+use Gyroscops\Api\Client;
+use Kiboko\Component\Satellite\Cloud\DTO\WorkflowId;
+
+interface WorkflowInterface
+{
+    public static function fromLegacyConfiguration(array $configuration): DTO\Workflow;
+
+    public static function fromApiWithId(Client $client, WorkflowId $id, array $configuration): DTO\ReferencedPipeline;
+
+    public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedPipeline;
+
+    public function create(DTO\PipelineInterface $pipeline): DTO\CommandBatch;
+
+    public function update(DTO\ReferencedPipeline $actual, DTO\PipelineInterface $desired): DTO\CommandBatch;
+
+    public function remove(DTO\PipelineId $id): DTO\CommandBatch;
+}

--- a/src/Cloud/WorkflowInterface.php
+++ b/src/Cloud/WorkflowInterface.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace Kiboko\Component\Satellite\Cloud;
 
 use Gyroscops\Api\Client;
-use Kiboko\Component\Satellite\Cloud\DTO;
 
 interface WorkflowInterface
 {
     public static function fromLegacyConfiguration(array $configuration): DTO\Workflow;
 
-    public static function fromApiWithId(Client $client, DTO\WorkflowId $id, array $configuration): DTO\ReferencedWorkflow;
+    public static function fromApiWithId(Client $client, DTO\WorkflowId $id): DTO\ReferencedWorkflow;
 
-    public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedWorkflow;
+    public static function fromApiWithCode(Client $client, string $code): DTO\ReferencedWorkflow;
 
     public function create(DTO\WorkflowInterface $workflow): DTO\CommandBatch;
 

--- a/src/Cloud/WorkflowInterface.php
+++ b/src/Cloud/WorkflowInterface.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Kiboko\Component\Satellite\Cloud;
 
 use Gyroscops\Api\Client;
-use Kiboko\Component\Satellite\Cloud\DTO\WorkflowId;
+use Kiboko\Component\Satellite\Cloud\DTO;
 
 interface WorkflowInterface
 {
     public static function fromLegacyConfiguration(array $configuration): DTO\Workflow;
 
-    public static function fromApiWithId(Client $client, WorkflowId $id, array $configuration): DTO\ReferencedPipeline;
+    public static function fromApiWithId(Client $client, DTO\WorkflowId $id, array $configuration): DTO\ReferencedWorkflow;
 
-    public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedPipeline;
+    public static function fromApiWithCode(Client $client, string $code, array $configuration): DTO\ReferencedWorkflow;
 
-    public function create(DTO\PipelineInterface $pipeline): DTO\CommandBatch;
+    public function create(DTO\WorkflowInterface $workflow): DTO\CommandBatch;
 
-    public function update(DTO\ReferencedPipeline $actual, DTO\PipelineInterface $desired): DTO\CommandBatch;
+    public function update(DTO\ReferencedWorkflow $actual, DTO\WorkflowInterface $desired): DTO\CommandBatch;
 
-    public function remove(DTO\PipelineId $id): DTO\CommandBatch;
+    public function remove(DTO\WorkflowId $id): DTO\CommandBatch;
 }

--- a/src/Cloud/WorkflowInterface.php
+++ b/src/Cloud/WorkflowInterface.php
@@ -14,9 +14,9 @@ interface WorkflowInterface
 
     public static function fromApiWithCode(Client $client, string $code): DTO\ReferencedWorkflow;
 
-    public function create(DTO\WorkflowInterface $workflow): DTO\CommandBatch;
+    public function create(DTO\SatelliteInterface&DTO\WorkflowInterface $workflow): DTO\CommandBatch;
 
-    public function update(DTO\ReferencedWorkflow $actual, DTO\WorkflowInterface $desired): DTO\CommandBatch;
+    public function update(DTO\ReferencedWorkflow $actual, DTO\SatelliteInterface&DTO\WorkflowInterface $desired): DTO\CommandBatch;
 
     public function remove(DTO\WorkflowId $id): DTO\CommandBatch;
 }

--- a/src/Console/Command/WorkflowRunCommand.php
+++ b/src/Console/Command/WorkflowRunCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 #[Console\Attribute\AsCommand('run:workflow', 'Run a data flow satellite (pipeline or workflow).', hidden: true)]
-final class WorkflowRunCommand extends Console\Command\Command
+final class WorkflowRunCommand extends RunCommand
 {
     protected function configure(): void
     {

--- a/src/Pipeline/Extractor.php
+++ b/src/Pipeline/Extractor.php
@@ -19,7 +19,8 @@ final readonly class Extractor implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {}
+    ) {
+    }
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Pipeline/Extractor.php
+++ b/src/Pipeline/Extractor.php
@@ -19,8 +19,7 @@ final readonly class Extractor implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {
-    }
+    ) {}
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Pipeline/Loader.php
+++ b/src/Pipeline/Loader.php
@@ -19,7 +19,8 @@ final readonly class Loader implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {}
+    ) {
+    }
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Pipeline/Loader.php
+++ b/src/Pipeline/Loader.php
@@ -19,8 +19,7 @@ final readonly class Loader implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {
-    }
+    ) {}
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Pipeline/Transformer.php
+++ b/src/Pipeline/Transformer.php
@@ -19,7 +19,8 @@ final readonly class Transformer implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {}
+    ) {
+    }
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Pipeline/Transformer.php
+++ b/src/Pipeline/Transformer.php
@@ -19,8 +19,7 @@ final readonly class Transformer implements StepInterface
         private ?string $plugin,
         private ?string $key,
         private ExpressionLanguage $interpreter = new Satellite\ExpressionLanguage()
-    ) {
-    }
+    ) {}
 
     public function __invoke(array $config, Pipeline $pipeline, StepRepositoryInterface $repository): void
     {

--- a/src/Plugin/Batching/Builder/Fork.php
+++ b/src/Plugin/Batching/Builder/Fork.php
@@ -52,7 +52,7 @@ final class Fork implements StepBuilderInterface
                 name: null,
                 subNodes: [
                     'implements' => [
-                        new Node\Name\FullyQualified(\Kiboko\Contract\Pipeline\TransformerInterface::class),
+                        new Node\Name\FullyQualified('Kiboko\\Contract\\Pipeline\\TransformerInterface::class'),
                     ],
                     'stmts' => [
                         new Node\Stmt\ClassMethod(

--- a/src/Plugin/Batching/Builder/Merge.php
+++ b/src/Plugin/Batching/Builder/Merge.php
@@ -146,7 +146,7 @@ final class Merge implements StepBuilderInterface
                                                                 var: new Node\Expr\Variable('line'),
                                                                 expr: new Node\Expr\Yield_(
                                                                     value: new Node\Expr\New_(
-                                                                        class: new Node\Name\FullyQualified('Kiboko\\Component\\Bucket\\AcceptanceResultBucket:'),
+                                                                        class: new Node\Name\FullyQualified('Kiboko\\Component\\Bucket\\AcceptanceResultBucket'),
                                                                         args: [
                                                                             new Node\Arg(
                                                                                 new Node\Expr\PropertyFetch(

--- a/src/Service.php
+++ b/src/Service.php
@@ -276,7 +276,7 @@ final class Service implements Configurator\FactoryInterface
             )
         );
 
-        foreach ($config['workflow']['jobs'] as $job) {
+        foreach ($config['workflow']['jobs'] as $code => $job) {
             if (\array_key_exists('pipeline', $job)) {
                 $pipeline = $this->compilePipelineJob($job);
                 $pipelineFilename = sprintf('%s.php', uniqid('pipeline'));
@@ -293,7 +293,7 @@ final class Service implements Configurator\FactoryInterface
                     )
                 );
 
-                $workflow->addPipeline($job['pipeline']['code'], $pipelineFilename);
+                $workflow->addPipeline($code, $pipelineFilename);
             } elseif (\array_key_exists('action', $job)) {
                 $action = $this->compileActionJob($job);
                 $actionFilename = sprintf('%s.php', uniqid('action'));
@@ -310,7 +310,7 @@ final class Service implements Configurator\FactoryInterface
                     )
                 );
 
-                $workflow->addAction($job['action']['code'], $actionFilename);
+                $workflow->addAction($code, $actionFilename);
             } else {
                 throw new \LogicException('Not implemented');
             }

--- a/src/Service.php
+++ b/src/Service.php
@@ -276,7 +276,7 @@ final class Service implements Configurator\FactoryInterface
             )
         );
 
-        foreach ($config['workflow']['jobs'] as $code => $job) {
+        foreach ($config['workflow']['jobs'] as $job) {
             if (\array_key_exists('pipeline', $job)) {
                 $pipeline = $this->compilePipelineJob($job);
                 $pipelineFilename = sprintf('%s.php', uniqid('pipeline'));
@@ -293,7 +293,7 @@ final class Service implements Configurator\FactoryInterface
                     )
                 );
 
-                $workflow->addPipeline($code, $pipelineFilename);
+                $workflow->addPipeline($job['pipeline']['code'], $pipelineFilename);
             } elseif (\array_key_exists('action', $job)) {
                 $action = $this->compileActionJob($job);
                 $actionFilename = sprintf('%s.php', uniqid('action'));
@@ -310,7 +310,7 @@ final class Service implements Configurator\FactoryInterface
                     )
                 );
 
-                $workflow->addAction($code, $actionFilename);
+                $workflow->addAction($job['action']['code'], $actionFilename);
             } else {
                 throw new \LogicException('Not implemented');
             }


### PR DESCRIPTION
Pour utiliser les commandes Cloud, il faut utiliser la version 0.3 de la configuration.

**Pourquoi ?**
- Cette version apporte de nouvelle options dans la configuration compatibles avec le Cloud qui ne sont pas disponibles dans l'ancienne config.
- Permet d'avoir un code plus simple et plus facile à maintenir.
- Permet dans le long terme de supprimer l'ancienne configuration