### PR TITLE
Made  the step code mandatory to avoid problems

### DIFF
--- a/src/Cloud/Workflow.php
+++ b/src/Cloud/Workflow.php
@@ -34,10 +34,9 @@ final readonly class Workflow implements WorkflowInterface
             $configuration['code'] ?? sprintf('workflow%s', $random),
             new DTO\JobList(
                 ...array_map(
-                    function (array $config, int $order) {
+                    function (string $code, array $config, int $order) {
                         if (\array_key_exists('pipeline', $config)) {
                             $name = $config['pipeline']['name'] ?? sprintf('pipeline%d', $order);
-                            $code = $config['pipeline']['code'] ?? sprintf('pipeline%d', $order);
                             unset($config['pipeline']['name'], $config['pipeline']['code']);
 
                             array_walk_recursive($config, function (&$value): void {
@@ -50,13 +49,16 @@ final readonly class Workflow implements WorkflowInterface
                                 $name,
                                 new JobCode($code),
                                 new StepList(
-                                    ...array_map(fn (array $step, int $order) => new Step(
-                                        $step['name'] ?? sprintf('step%d', $order),
-                                        new StepCode($step['code'] ?? sprintf('step%d', $order)),
-                                        $step,
-                                        new ProbeList(),
-                                        $order
-                                    ),
+                                    ...array_map(function (string $code, array $step, int $order) {
+                                            return new Step(
+                                                $step['name'] ?? sprintf('step%d', $order),
+                                                new StepCode($code ?? sprintf('step%d', $order)),
+                                                $step,
+                                                new ProbeList(),
+                                                $order
+                                            );
+                                        },
+                                        array_keys($config['pipeline']['steps']),
                                         $config['pipeline']['steps'],
                                         range(0, (is_countable($config['pipeline']['steps']) ? \count($config['pipeline']['steps']) : 0) - 1)
                                     ),
@@ -67,7 +69,6 @@ final readonly class Workflow implements WorkflowInterface
 
                         if (\array_key_exists('action', $config)) {
                             $name = $config['action']['name'] ?? sprintf('action%d', $order);
-                            $code = $config['action']['code'] ?? sprintf('action%d', $order);
                             unset($config['action']['name'], $config['action']['code']);
 
                             array_walk_recursive($config, function (&$value): void {
@@ -90,8 +91,9 @@ final readonly class Workflow implements WorkflowInterface
 
                         throw new \RuntimeException('This type is currently not supported.');
                     },
+                    array_keys($configuration['workflow']['jobs']),
                     $configuration['workflow']['jobs'],
-                    range(0, (is_countable($configuration['workflow']['jobs']) ? \count($configuration['workflow']['jobs']) : 0) - 1)
+                    range(0, (is_countable($configuration['workflow']['jobs']) ? \count($configuration['workflow']['jobs']) : 0) - 1),
                 )
             ),
             new Composer(

--- a/src/Runtime/Pipeline/Configuration.php
+++ b/src/Runtime/Pipeline/Configuration.php
@@ -44,6 +44,7 @@ final class Configuration implements Configurator\RuntimeConfigurationInterface
 
         /* @phpstan-ignore-next-line */
         $builder->getRootNode()
+            ->useAttributeAsKey('code')
             ->requiresAtLeastOneElement()
             ->cannotBeEmpty()
             ->isRequired()

--- a/src/Service.php
+++ b/src/Service.php
@@ -350,7 +350,9 @@ final class Service implements Configurator\FactoryInterface
             }
         }
 
-        foreach ($config['pipeline']['steps'] as $step) {
+        foreach ($config['pipeline']['steps'] as $code => $step) {
+            $step['code'] = $code;
+
             $plugins = array_intersect_key($this->plugins, $step);
             foreach ($plugins as $plugin) {
                 $plugin->appendTo($step, $repository);


### PR DESCRIPTION
J'ai fait en sorte qu'une erreur soit lancée quand on ne fournit pas le code d'une step dans la configuration.

![image (6)](https://github.com/user-attachments/assets/294ec308-ecad-462f-99f3-a402c8732a94)

Voici les 2 façon de comment on peut fournit ce code  :

![image (7)](https://github.com/user-attachments/assets/552dc2c9-e5bd-424b-932d-d6e965d46baa)

![image (8)](https://github.com/user-attachments/assets/880ebed1-36fd-4eb6-a2da-907d939d54b5)

J'ai aussi fait en sorte de corriger les informations envoyées par la commande cloud.